### PR TITLE
hotfix: limit httpx version to 0.28.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.9.5,<4.0.0
-httpx>=0.27.0,<1.0.0
+httpx>=0.27.0,<0.28.0
 sphinx-rtd-theme
 inflection>=0.5.1
 black

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         'aiohttp>=3.9.5,<4.0.0',
-        'httpx>=0.27.0,<1.0.0',
+        'httpx>=0.27.0,<0.28.0',
     ],
 )

--- a/src/mattermostautodriver/version.py
+++ b/src/mattermostautodriver/version.py
@@ -1,2 +1,2 @@
-full_version = "2.2.0"
+full_version = "2.2.1"
 short_version = ".".join(full_version.split(".", 2)[:2])


### PR DESCRIPTION
Hi
httpx has removed proxies args from Client in 0.28.0
So this error will be raise when httpx==0.28.0 is installed:
```
TypeError: Client.__init__() got an unexpected keyword argument 'proxies'
```

A hotfix solution can be just to limit httpx version...