### PR TITLE
Fixed "proxy" variable name for httpx ^0.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp>=3.9.5,<4.0.0
-httpx>=0.27.0,<0.28.0
+httpx>=0.28.0
 sphinx-rtd-theme
 inflection>=0.5.1
 black

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         'aiohttp>=3.9.5,<4.0.0',
-        'httpx>=0.27.0,<0.28.0',
+        'httpx>=0.28.0',
     ],
 )

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -34,9 +34,9 @@ class BaseClient:
         self._cookies = None
         self._userid = ""
         self._username = ""
-        self._proxies = None
+        self._proxy = None
         if options["proxy"]:
-            self._proxies = {"all://": options["proxy"]}
+            self._proxy = {"all://": options["proxy"]}
 
     @staticmethod
     def _make_url(scheme, url, port):
@@ -203,7 +203,7 @@ class Client(BaseClient):
         super().__init__(options)
         self.client = httpx.Client(
             http2=options.get("http2", False),
-            proxies=self._proxies,
+            proxy=self._proxy,
             verify=options.get("verify", True),
         )
 
@@ -255,7 +255,7 @@ class AsyncClient(BaseClient):
         super().__init__(options)
         self.client = httpx.AsyncClient(
             http2=options.get("http2", False),
-            proxies=self._proxies,
+            proxy=self._proxy,
             verify=options.get("verify", True),
         )
 


### PR DESCRIPTION
#15
Hi! I fixed "proxy" value name, as it was changed in httpx 0.28
https://github.com/encode/httpx/commit/f8981f3d124f9b8db9073fd5c8afa11acb55a738