### PR TITLE
Add type-hints to endpoint methods

### DIFF
--- a/bin/generate_endpoints_ast.py
+++ b/bin/generate_endpoints_ast.py
@@ -71,7 +71,6 @@ def get_parameters(params, key):
         "description": "",
         "parameters": [],
         "required": False,
-        "required_fields": [],
     }
 
     for param in params:
@@ -94,20 +93,17 @@ def get_properties(schema):
     props = schema.get("properties", {})
     required = schema.get("required", [])
 
-    return (
-        required,
-        [
-            Parameter(
-                prop,
-                values.get("description", ""),
-                prop in required,
-                values.get("type", None),
-                values.get("default", None),
-                values.get("format", None),
-            )
-            for prop, values in props.items()
-        ],
-    )
+    return [
+        Parameter(
+            prop,
+            values.get("description", ""),
+            prop in required,
+            values.get("type", None),
+            values.get("default", None),
+            values.get("format", None),
+        )
+        for prop, values in props.items()
+    ]
 
 
 def get_descriptions(params):
@@ -133,7 +129,7 @@ def parse_req_body(req_body_type, schema):
     if req_body_type in ("application/json", "multipart/form-data"):
         return get_properties(schema)
     elif req_body_type == "application/x-www-form-urlencoded":
-        return (False, [])
+        return []
     else:
         raise NotImplementedError(f"request body type {req_body_type} is not supported")
 
@@ -167,7 +163,7 @@ def get_requestbody_parameters(body, request_type):
 
     req_body_type = get_request_body_type(body)
 
-    required_fields, parameters = parse_req_body(req_body_type, body["content"][req_body_type]["schema"])
+    parameters = parse_req_body(req_body_type, body["content"][req_body_type]["schema"])
 
     binary = any(filter(lambda x: x.format == "binary", parameters))
 
@@ -176,7 +172,6 @@ def get_requestbody_parameters(body, request_type):
         "parameters": parameters,
         "required": body.get("required", False),
         "binary": binary,
-        "required_fields": required_fields,
     }
 
 

--- a/bin/generate_endpoints_ast.py
+++ b/bin/generate_endpoints_ast.py
@@ -387,7 +387,7 @@ def prepare_def_keywords(url_params, payload_params, operation_arg, req_body_typ
     args = [ast.arg(arg="self")]
     kwargs = []
 
-    request_params = url_params["parameters"]
+    request_params = [*url_params["parameters"]]
 
     params = payload_params.get("parameters", [])
 
@@ -405,7 +405,17 @@ def prepare_def_keywords(url_params, payload_params, operation_arg, req_body_typ
     # Ensure params without default values come first
     request_params.sort(key=lambda param: 0 if param.default is None and param.required else 1)
 
-    for param in url_params["parameters"]:
+    existing_params = []
+    unique_params = []
+
+    for param in request_params:
+        if param.name in existing_params:
+            print(param.name)
+            continue
+        existing_params.append(param.name)
+        unique_params.append(param)
+
+    for param in unique_params:
         add_param(param.name, param.schema, param.required, param.format == "binary", param.default, args, kwargs)
 
     return {"args": args, "defaults": kwargs}

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -129,6 +129,14 @@ class BaseClient:
         return {"Authorization": "Bearer {token:s}".format(token=self._token)}
 
     def _build_request(self, method, options=None, params=None, data=None, files=None):
+        def filter_dict(d):
+            filtered_d = {k: v for k, v in d.items() if v is not None}
+
+            if filtered_d:
+                return filtered_d
+
+            return None
+
         if params is None:
             params = {}
         if data is None:
@@ -137,16 +145,21 @@ class BaseClient:
 
         request_params = {"headers": self.auth_header(), "timeout": self.request_timeout}
 
-        if params is not None:
-            request_params["params"] = params
+        filtered_params = filter_dict(params)
+        filtered_options = filter_dict(options)
+        filtered_data = filter_dict(data)
+        filtered_files = filter_dict(files)
+
+        if filtered_params is not None:
+            request_params["params"] = filtered_params
 
         if method in ("post", "put"):
-            if options is not None:
-                request_params["json"] = options
-            if data is not None:
-                request_params["data"] = data
-            if files is not None:
-                request_params["files"] = files
+            if filtered_options is not None:
+                request_params["json"] = filtered_options
+            if filtered_data is not None:
+                request_params["data"] = filtered_data
+            if filtered_files is not None:
+                request_params["files"] = filtered_files
 
         if self._auth is not None:
             request_params["auth"] = self._auth()

--- a/src/mattermostautodriver/driver.py
+++ b/src/mattermostautodriver/driver.py
@@ -77,7 +77,7 @@ class BaseDriver:
             # Load module and find the main module class
             # e.g. mattermostautodriver.endpoints.users -> Users
             module = importlib.import_module(f".endpoints.{end}", __package__)
-            classnames = [x for x in dir(module) if x != "Base" and not x.startswith("_")]
+            classnames = [x for x in dir(module) if x != "Base" and not x.startswith("_") and x not in ["Any", "BinaryIO"]]
 
             assert len(classnames) == 1, f"Unexpected endpoint configuration: {end}. Please report bug"
 

--- a/src/mattermostautodriver/endpoints/access_control.py
+++ b/src/mattermostautodriver/endpoints/access_control.py
@@ -1,16 +1,17 @@
 from .base import Base
+from typing import Any
 
 
 class AccessControl(Base):
 
-    def create_access_control_policy(self, options):
+    def create_access_control_policy(self, options: Any):
         """Create an access control policy
         `Read in Mattermost API docs (access_control - CreateAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/CreateAccessControlPolicy>`_
 
         """
         return self.client.put("""/api/v4/access_control_policies""", options=options)
 
-    def check_access_control_policy_expression(self, options):
+    def check_access_control_policy_expression(self, expression: str | None = None):
         """Check an access control policy expression
 
         expression: The expression to check.
@@ -18,23 +19,26 @@ class AccessControl(Base):
         `Read in Mattermost API docs (access_control - CheckAccessControlPolicyExpression) <https://api.mattermost.com/#tag/access_control/operation/CheckAccessControlPolicyExpression>`_
 
         """
-        return self.client.post("""/api/v4/access_control_policies/cel/check""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"expression": expression}
+        return self.client.post(
+            """/api/v4/access_control_policies/cel/check""", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def test_access_control_policy_expression(self, options):
+    def test_access_control_policy_expression(self, options: Any):
         """Test an access control policy expression
         `Read in Mattermost API docs (access_control - TestAccessControlPolicyExpression) <https://api.mattermost.com/#tag/access_control/operation/TestAccessControlPolicyExpression>`_
 
         """
         return self.client.post("""/api/v4/access_control_policies/cel/test""", options=options)
 
-    def search_access_control_policies(self, options):
+    def search_access_control_policies(self, options: Any):
         """Search access control policies
         `Read in Mattermost API docs (access_control - SearchAccessControlPolicies) <https://api.mattermost.com/#tag/access_control/operation/SearchAccessControlPolicies>`_
 
         """
         return self.client.post("""/api/v4/access_control_policies/search""", options=options)
 
-    def get_access_control_policy_autocomplete_fields(self, params=None):
+    def get_access_control_policy_autocomplete_fields(self, after: str | None = None, limit: int = 60):
         """Get autocomplete fields for access control policies
 
         after: The field ID to start after for pagination.
@@ -43,9 +47,13 @@ class AccessControl(Base):
         `Read in Mattermost API docs (access_control - GetAccessControlPolicyAutocompleteFields) <https://api.mattermost.com/#tag/access_control/operation/GetAccessControlPolicyAutocompleteFields>`_
 
         """
-        return self.client.get("""/api/v4/access_control_policies/cel/autocomplete/fields""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"after": after, "limit": limit}
+        return self.client.get(
+            """/api/v4/access_control_policies/cel/autocomplete/fields""",
+            params=params_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def get_access_control_policy(self, policy_id):
+    def get_access_control_policy(self, policy_id: str):
         """Get an access control policy
 
         policy_id: The ID of the access control policy.
@@ -55,7 +63,7 @@ class AccessControl(Base):
         """
         return self.client.get(f"/api/v4/access_control_policies/{policy_id}")
 
-    def delete_access_control_policy(self, policy_id):
+    def delete_access_control_policy(self, policy_id: str):
         """Delete an access control policy
 
         policy_id: The ID of the access control policy.
@@ -65,7 +73,7 @@ class AccessControl(Base):
         """
         return self.client.delete(f"/api/v4/access_control_policies/{policy_id}")
 
-    def update_access_control_policy_active_status(self, policy_id, params=None):
+    def update_access_control_policy_active_status(self, policy_id: str, active: bool):
         """Activate or deactivate an access control policy
 
         policy_id: The ID of the access control policy.
@@ -74,9 +82,12 @@ class AccessControl(Base):
         `Read in Mattermost API docs (access_control - UpdateAccessControlPolicyActiveStatus) <https://api.mattermost.com/#tag/access_control/operation/UpdateAccessControlPolicyActiveStatus>`_
 
         """
-        return self.client.get(f"/api/v4/access_control_policies/{policy_id}/activate", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"active": active}
+        return self.client.get(
+            f"/api/v4/access_control_policies/{policy_id}/activate", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def assign_access_control_policy_to_channels(self, policy_id, options):
+    def assign_access_control_policy_to_channels(self, policy_id: str, channel_ids: list[str] | None = None):
         """Assign an access control policy to channels
 
         policy_id: The ID of the access control policy.
@@ -85,9 +96,12 @@ class AccessControl(Base):
         `Read in Mattermost API docs (access_control - AssignAccessControlPolicyToChannels) <https://api.mattermost.com/#tag/access_control/operation/AssignAccessControlPolicyToChannels>`_
 
         """
-        return self.client.post(f"/api/v4/access_control_policies/{policy_id}/assign", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_ids": channel_ids}
+        return self.client.post(
+            f"/api/v4/access_control_policies/{policy_id}/assign", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def unassign_access_control_policy_from_channels(self, policy_id, params):
+    def unassign_access_control_policy_from_channels(self, policy_id: str, channel_ids: list[str] | None = None):
         """Unassign an access control policy from channels
 
         policy_id: The ID of the access control policy.
@@ -96,9 +110,12 @@ class AccessControl(Base):
         `Read in Mattermost API docs (access_control - UnassignAccessControlPolicyFromChannels) <https://api.mattermost.com/#tag/access_control/operation/UnassignAccessControlPolicyFromChannels>`_
 
         """
-        return self.client.delete(f"/api/v4/access_control_policies/{policy_id}/unassign", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_ids": channel_ids}
+        return self.client.delete(
+            f"/api/v4/access_control_policies/{policy_id}/unassign", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channels_for_access_control_policy(self, policy_id, params=None):
+    def get_channels_for_access_control_policy(self, policy_id: str, after: str | None = None, limit: int = 60):
         """Get channels for an access control policy
 
         policy_id: The ID of the access control policy.
@@ -108,9 +125,13 @@ class AccessControl(Base):
         `Read in Mattermost API docs (access_control - GetChannelsForAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/GetChannelsForAccessControlPolicy>`_
 
         """
-        return self.client.get(f"/api/v4/access_control_policies/{policy_id}/resources/channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"after": after, "limit": limit}
+        return self.client.get(
+            f"/api/v4/access_control_policies/{policy_id}/resources/channels",
+            params=params_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def search_channels_for_access_control_policy(self, policy_id, options):
+    def search_channels_for_access_control_policy(self, policy_id: str, options: Any):
         """Search channels for an access control policy
 
         policy_id: The ID of the access control policy.
@@ -122,7 +143,7 @@ class AccessControl(Base):
             f"/api/v4/access_control_policies/{policy_id}/resources/channels/search", options=options
         )
 
-    def get_channel_access_control_attributes(self, channel_id):
+    def get_channel_access_control_attributes(self, channel_id: str):
         """Get access control attributes for a channel
 
         channel_id: The ID of the channel.
@@ -132,7 +153,7 @@ class AccessControl(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}/access_control/attributes")
 
-    def get_cel_visual_ast(self, options):
+    def get_cel_visual_ast(self, options: Any):
         """Get the visual AST for a CEL expression
         `Read in Mattermost API docs (access_control - GetCELVisualAST) <https://api.mattermost.com/#tag/access_control/operation/GetCELVisualAST>`_
 

--- a/src/mattermostautodriver/endpoints/access_control.py
+++ b/src/mattermostautodriver/endpoints/access_control.py
@@ -1,0 +1,140 @@
+from .base import Base
+
+
+class AccessControl(Base):
+
+    def create_access_control_policy(self, options):
+        """Create an access control policy
+        `Read in Mattermost API docs (access_control - CreateAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/CreateAccessControlPolicy>`_
+
+        """
+        return self.client.put("""/api/v4/access_control_policies""", options=options)
+
+    def check_access_control_policy_expression(self, options):
+        """Check an access control policy expression
+
+        expression: The expression to check.
+
+        `Read in Mattermost API docs (access_control - CheckAccessControlPolicyExpression) <https://api.mattermost.com/#tag/access_control/operation/CheckAccessControlPolicyExpression>`_
+
+        """
+        return self.client.post("""/api/v4/access_control_policies/cel/check""", options=options)
+
+    def test_access_control_policy_expression(self, options):
+        """Test an access control policy expression
+        `Read in Mattermost API docs (access_control - TestAccessControlPolicyExpression) <https://api.mattermost.com/#tag/access_control/operation/TestAccessControlPolicyExpression>`_
+
+        """
+        return self.client.post("""/api/v4/access_control_policies/cel/test""", options=options)
+
+    def search_access_control_policies(self, options):
+        """Search access control policies
+        `Read in Mattermost API docs (access_control - SearchAccessControlPolicies) <https://api.mattermost.com/#tag/access_control/operation/SearchAccessControlPolicies>`_
+
+        """
+        return self.client.post("""/api/v4/access_control_policies/search""", options=options)
+
+    def get_access_control_policy_autocomplete_fields(self, params=None):
+        """Get autocomplete fields for access control policies
+
+        after: The field ID to start after for pagination.
+        limit: The maximum number of fields to return.
+
+        `Read in Mattermost API docs (access_control - GetAccessControlPolicyAutocompleteFields) <https://api.mattermost.com/#tag/access_control/operation/GetAccessControlPolicyAutocompleteFields>`_
+
+        """
+        return self.client.get("""/api/v4/access_control_policies/cel/autocomplete/fields""", params=params)
+
+    def get_access_control_policy(self, policy_id):
+        """Get an access control policy
+
+        policy_id: The ID of the access control policy.
+
+        `Read in Mattermost API docs (access_control - GetAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/GetAccessControlPolicy>`_
+
+        """
+        return self.client.get(f"/api/v4/access_control_policies/{policy_id}")
+
+    def delete_access_control_policy(self, policy_id):
+        """Delete an access control policy
+
+        policy_id: The ID of the access control policy.
+
+        `Read in Mattermost API docs (access_control - DeleteAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/DeleteAccessControlPolicy>`_
+
+        """
+        return self.client.delete(f"/api/v4/access_control_policies/{policy_id}")
+
+    def update_access_control_policy_active_status(self, policy_id, params=None):
+        """Activate or deactivate an access control policy
+
+        policy_id: The ID of the access control policy.
+        active: Set to "true" to activate, "false" to deactivate.
+
+        `Read in Mattermost API docs (access_control - UpdateAccessControlPolicyActiveStatus) <https://api.mattermost.com/#tag/access_control/operation/UpdateAccessControlPolicyActiveStatus>`_
+
+        """
+        return self.client.get(f"/api/v4/access_control_policies/{policy_id}/activate", params=params)
+
+    def assign_access_control_policy_to_channels(self, policy_id, options):
+        """Assign an access control policy to channels
+
+        policy_id: The ID of the access control policy.
+        channel_ids: The IDs of the channels to assign the policy to.
+
+        `Read in Mattermost API docs (access_control - AssignAccessControlPolicyToChannels) <https://api.mattermost.com/#tag/access_control/operation/AssignAccessControlPolicyToChannels>`_
+
+        """
+        return self.client.post(f"/api/v4/access_control_policies/{policy_id}/assign", options=options)
+
+    def unassign_access_control_policy_from_channels(self, policy_id, params):
+        """Unassign an access control policy from channels
+
+        policy_id: The ID of the access control policy.
+        channel_ids: The IDs of the channels to unassign the policy from.
+
+        `Read in Mattermost API docs (access_control - UnassignAccessControlPolicyFromChannels) <https://api.mattermost.com/#tag/access_control/operation/UnassignAccessControlPolicyFromChannels>`_
+
+        """
+        return self.client.delete(f"/api/v4/access_control_policies/{policy_id}/unassign", params=params)
+
+    def get_channels_for_access_control_policy(self, policy_id, params=None):
+        """Get channels for an access control policy
+
+        policy_id: The ID of the access control policy.
+        after: The channel ID to start after for pagination.
+        limit: The maximum number of channels to return.
+
+        `Read in Mattermost API docs (access_control - GetChannelsForAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/GetChannelsForAccessControlPolicy>`_
+
+        """
+        return self.client.get(f"/api/v4/access_control_policies/{policy_id}/resources/channels", params=params)
+
+    def search_channels_for_access_control_policy(self, policy_id, options):
+        """Search channels for an access control policy
+
+        policy_id: The ID of the access control policy.
+
+        `Read in Mattermost API docs (access_control - SearchChannelsForAccessControlPolicy) <https://api.mattermost.com/#tag/access_control/operation/SearchChannelsForAccessControlPolicy>`_
+
+        """
+        return self.client.post(
+            f"/api/v4/access_control_policies/{policy_id}/resources/channels/search", options=options
+        )
+
+    def get_channel_access_control_attributes(self, channel_id):
+        """Get access control attributes for a channel
+
+        channel_id: The ID of the channel.
+
+        `Read in Mattermost API docs (access_control - GetChannelAccessControlAttributes) <https://api.mattermost.com/#tag/access_control/operation/GetChannelAccessControlAttributes>`_
+
+        """
+        return self.client.get(f"/api/v4/channels/{channel_id}/access_control/attributes")
+
+    def get_cel_visual_ast(self, options):
+        """Get the visual AST for a CEL expression
+        `Read in Mattermost API docs (access_control - GetCELVisualAST) <https://api.mattermost.com/#tag/access_control/operation/GetCELVisualAST>`_
+
+        """
+        return self.client.post("""/api/v4/access_control_policies/cel/visual_ast""", options=options)

--- a/src/mattermostautodriver/endpoints/access_control.py
+++ b/src/mattermostautodriver/endpoints/access_control.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class AccessControl(Base):

--- a/src/mattermostautodriver/endpoints/audit_logs.py
+++ b/src/mattermostautodriver/endpoints/audit_logs.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class AuditLogs(Base):
 
-    def add_audit_log_certificate(self, files, data=None):
+    def add_audit_log_certificate(self, certificate: str):
         """Upload audit log certificate
 
         certificate: The certificate file
@@ -11,7 +12,8 @@ class AuditLogs(Base):
         `Read in Mattermost API docs (audit_logs - AddAuditLogCertificate) <https://api.mattermost.com/#tag/audit_logs/operation/AddAuditLogCertificate>`_
 
         """
-        return self.client.post("""/api/v4/audit_logs/certificate""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"certificate": certificate}
+        return self.client.post("""/api/v4/audit_logs/certificate""", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def remove_audit_log_certificate(self):
         """Remove audit log certificate

--- a/src/mattermostautodriver/endpoints/audit_logs.py
+++ b/src/mattermostautodriver/endpoints/audit_logs.py
@@ -1,10 +1,10 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class AuditLogs(Base):
 
-    def add_audit_log_certificate(self, certificate: str):
+    def add_audit_log_certificate(self, certificate: BinaryIO):
         """Upload audit log certificate
 
         certificate: The certificate file

--- a/src/mattermostautodriver/endpoints/audit_logs.py
+++ b/src/mattermostautodriver/endpoints/audit_logs.py
@@ -1,0 +1,21 @@
+from .base import Base
+
+
+class AuditLogs(Base):
+
+    def add_audit_log_certificate(self, files, data=None):
+        """Upload audit log certificate
+
+        certificate: The certificate file
+
+        `Read in Mattermost API docs (audit_logs - AddAuditLogCertificate) <https://api.mattermost.com/#tag/audit_logs/operation/AddAuditLogCertificate>`_
+
+        """
+        return self.client.post("""/api/v4/audit_logs/certificate""", files=files, data=data)
+
+    def remove_audit_log_certificate(self):
+        """Remove audit log certificate
+        `Read in Mattermost API docs (audit_logs - RemoveAuditLogCertificate) <https://api.mattermost.com/#tag/audit_logs/operation/RemoveAuditLogCertificate>`_
+
+        """
+        return self.client.delete("""/api/v4/audit_logs/certificate""")

--- a/src/mattermostautodriver/endpoints/authentication.py
+++ b/src/mattermostautodriver/endpoints/authentication.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Authentication(Base):
 
-    def migrate_auth_to_ldap(self, options=None):
+    def migrate_auth_to_ldap(self, from_: str, match_field: str, force: bool):
         """Migrate user accounts authentication type to LDAP.
 
         from: The current authentication type for the matched users.
@@ -13,9 +14,10 @@ class Authentication(Base):
         `Read in Mattermost API docs (authentication - MigrateAuthToLdap) <https://api.mattermost.com/#tag/authentication/operation/MigrateAuthToLdap>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/ldap""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "match_field": match_field, "force": force}
+        return self.client.post("""/api/v4/users/migrate_auth/ldap""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def migrate_auth_to_saml(self, options=None):
+    def migrate_auth_to_saml(self, from_: str, matches: dict[str, Any], auto: bool):
         """Migrate user accounts authentication type to SAML.
 
         from: The current authentication type for the matched users.
@@ -25,4 +27,5 @@ class Authentication(Base):
         `Read in Mattermost API docs (authentication - MigrateAuthToSaml) <https://api.mattermost.com/#tag/authentication/operation/MigrateAuthToSaml>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "matches": matches, "auto": auto}
+        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/authentication.py
+++ b/src/mattermostautodriver/endpoints/authentication.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Authentication(Base):

--- a/src/mattermostautodriver/endpoints/bleve.py
+++ b/src/mattermostautodriver/endpoints/bleve.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Bleve(Base):

--- a/src/mattermostautodriver/endpoints/bleve.py
+++ b/src/mattermostautodriver/endpoints/bleve.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Bleve(Base):

--- a/src/mattermostautodriver/endpoints/bookmarks.py
+++ b/src/mattermostautodriver/endpoints/bookmarks.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Bookmarks(Base):

--- a/src/mattermostautodriver/endpoints/bookmarks.py
+++ b/src/mattermostautodriver/endpoints/bookmarks.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Bookmarks(Base):
 
-    def list_channel_bookmarks_for_channel(self, channel_id, params=None):
+    def list_channel_bookmarks_for_channel(self, channel_id: str, bookmarks_since: float | None = None):
         """Get channel bookmarks for Channel
 
         channel_id: Channel GUID
@@ -15,9 +16,21 @@ class Bookmarks(Base):
         `Read in Mattermost API docs (bookmarks - ListChannelBookmarksForChannel) <https://api.mattermost.com/#tag/bookmarks/operation/ListChannelBookmarksForChannel>`_
 
         """
-        return self.client.get(f"/api/v4/channels/{channel_id}/bookmarks", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"bookmarks_since": bookmarks_since}
+        return self.client.get(
+            f"/api/v4/channels/{channel_id}/bookmarks", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def create_channel_bookmark(self, channel_id, options):
+    def create_channel_bookmark(
+        self,
+        channel_id: str,
+        display_name: str,
+        type: str,
+        file_id: str | None = None,
+        link_url: str | None = None,
+        image_url: str | None = None,
+        emoji: str | None = None,
+    ):
         """Create channel bookmark
 
         channel_id: Channel GUID
@@ -33,9 +46,30 @@ class Bookmarks(Base):
         `Read in Mattermost API docs (bookmarks - CreateChannelBookmark) <https://api.mattermost.com/#tag/bookmarks/operation/CreateChannelBookmark>`_
 
         """
-        return self.client.post(f"/api/v4/channels/{channel_id}/bookmarks", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "file_id": file_id,
+            "display_name": display_name,
+            "link_url": link_url,
+            "image_url": image_url,
+            "emoji": emoji,
+            "type": type,
+        }
+        return self.client.post(
+            f"/api/v4/channels/{channel_id}/bookmarks", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_channel_bookmark(self, channel_id, bookmark_id, options):
+    def update_channel_bookmark(
+        self,
+        channel_id: str,
+        bookmark_id: str,
+        file_id: str | None = None,
+        display_name: str | None = None,
+        sort_order: int | None = None,
+        link_url: str | None = None,
+        image_url: str | None = None,
+        emoji: str | None = None,
+        type: str | None = None,
+    ):
         """Update channel bookmark
 
         channel_id: Channel GUID
@@ -53,9 +87,20 @@ class Bookmarks(Base):
         `Read in Mattermost API docs (bookmarks - UpdateChannelBookmark) <https://api.mattermost.com/#tag/bookmarks/operation/UpdateChannelBookmark>`_
 
         """
-        return self.client.patch(f"/api/v4/channels/{channel_id}/bookmarks/{bookmark_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "file_id": file_id,
+            "display_name": display_name,
+            "sort_order": sort_order,
+            "link_url": link_url,
+            "image_url": image_url,
+            "emoji": emoji,
+            "type": type,
+        }
+        return self.client.patch(
+            f"/api/v4/channels/{channel_id}/bookmarks/{bookmark_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def delete_channel_bookmark(self, channel_id, bookmark_id):
+    def delete_channel_bookmark(self, channel_id: str, bookmark_id: str):
         """Delete channel bookmark
 
         channel_id: Channel GUID
@@ -66,7 +111,7 @@ class Bookmarks(Base):
         """
         return self.client.delete(f"/api/v4/channels/{channel_id}/bookmarks/{bookmark_id}")
 
-    def update_channel_bookmark_sort_order(self, channel_id, bookmark_id, options=None):
+    def update_channel_bookmark_sort_order(self, channel_id: str, bookmark_id: str, options: float | None = None):
         """Update channel bookmark's order
 
         channel_id: Channel GUID

--- a/src/mattermostautodriver/endpoints/bots.py
+++ b/src/mattermostautodriver/endpoints/bots.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Bots(Base):
 
-    def convert_user_to_bot(self, user_id):
+    def convert_user_to_bot(self, user_id: str):
         """Convert a user into a bot
 
         user_id: User GUID
@@ -13,7 +14,7 @@ class Bots(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/convert_to_bot")
 
-    def create_bot(self, options):
+    def create_bot(self, username: str, display_name: str | None = None, description: str | None = None):
         """Create a bot
 
         username:
@@ -23,9 +24,20 @@ class Bots(Base):
         `Read in Mattermost API docs (bots - CreateBot) <https://api.mattermost.com/#tag/bots/operation/CreateBot>`_
 
         """
-        return self.client.post("""/api/v4/bots""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "username": username,
+            "display_name": display_name,
+            "description": description,
+        }
+        return self.client.post("""/api/v4/bots""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_bots(self, params=None):
+    def get_bots(
+        self,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        include_deleted: bool | None = None,
+        only_orphaned: bool | None = None,
+    ):
         """Get bots
 
         page: The page to select.
@@ -36,9 +48,17 @@ class Bots(Base):
         `Read in Mattermost API docs (bots - GetBots) <https://api.mattermost.com/#tag/bots/operation/GetBots>`_
 
         """
-        return self.client.get("""/api/v4/bots""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "include_deleted": include_deleted,
+            "only_orphaned": only_orphaned,
+        }
+        return self.client.get("""/api/v4/bots""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def patch_bot(self, bot_user_id, options):
+    def patch_bot(
+        self, bot_user_id: str, username: str, display_name: str | None = None, description: str | None = None
+    ):
         """Patch a bot
 
         bot_user_id: Bot user ID
@@ -49,9 +69,14 @@ class Bots(Base):
         `Read in Mattermost API docs (bots - PatchBot) <https://api.mattermost.com/#tag/bots/operation/PatchBot>`_
 
         """
-        return self.client.put(f"/api/v4/bots/{bot_user_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "username": username,
+            "display_name": display_name,
+            "description": description,
+        }
+        return self.client.put(f"/api/v4/bots/{bot_user_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_bot(self, bot_user_id, params=None):
+    def get_bot(self, bot_user_id: str, include_deleted: bool | None = None):
         """Get a bot
 
         bot_user_id: Bot user ID
@@ -60,9 +85,10 @@ class Bots(Base):
         `Read in Mattermost API docs (bots - GetBot) <https://api.mattermost.com/#tag/bots/operation/GetBot>`_
 
         """
-        return self.client.get(f"/api/v4/bots/{bot_user_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_deleted": include_deleted}
+        return self.client.get(f"/api/v4/bots/{bot_user_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def disable_bot(self, bot_user_id):
+    def disable_bot(self, bot_user_id: str):
         """Disable a bot
 
         bot_user_id: Bot user ID
@@ -72,7 +98,7 @@ class Bots(Base):
         """
         return self.client.post(f"/api/v4/bots/{bot_user_id}/disable")
 
-    def enable_bot(self, bot_user_id):
+    def enable_bot(self, bot_user_id: str):
         """Enable a bot
 
         bot_user_id: Bot user ID
@@ -82,7 +108,7 @@ class Bots(Base):
         """
         return self.client.post(f"/api/v4/bots/{bot_user_id}/enable")
 
-    def assign_bot(self, bot_user_id, user_id):
+    def assign_bot(self, bot_user_id: str, user_id: str):
         """Assign a bot to a user
 
         bot_user_id: Bot user ID
@@ -93,7 +119,7 @@ class Bots(Base):
         """
         return self.client.post(f"/api/v4/bots/{bot_user_id}/assign/{user_id}")
 
-    def get_bot_icon_image(self, bot_user_id):
+    def get_bot_icon_image(self, bot_user_id: str):
         """Get bot's LHS icon
 
         bot_user_id: Bot user ID
@@ -103,7 +129,7 @@ class Bots(Base):
         """
         return self.client.get(f"/api/v4/bots/{bot_user_id}/icon")
 
-    def set_bot_icon_image(self, bot_user_id, files, data=None):
+    def set_bot_icon_image(self, bot_user_id: str, image: str):
         """Set bot's LHS icon image
 
         bot_user_id: Bot user ID
@@ -112,9 +138,10 @@ class Bots(Base):
         `Read in Mattermost API docs (bots - SetBotIconImage) <https://api.mattermost.com/#tag/bots/operation/SetBotIconImage>`_
 
         """
-        return self.client.post(f"/api/v4/bots/{bot_user_id}/icon", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"image": image}
+        return self.client.post(f"/api/v4/bots/{bot_user_id}/icon", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def delete_bot_icon_image(self, bot_user_id):
+    def delete_bot_icon_image(self, bot_user_id: str):
         """Delete bot's LHS icon image
 
         bot_user_id: Bot user ID
@@ -124,7 +151,20 @@ class Bots(Base):
         """
         return self.client.delete(f"/api/v4/bots/{bot_user_id}/icon")
 
-    def convert_bot_to_user(self, bot_user_id, options):
+    def convert_bot_to_user(
+        self,
+        bot_user_id: str,
+        email: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        nickname: str | None = None,
+        locale: str | None = None,
+        position: str | None = None,
+        props: dict[str, Any] | None = None,
+        notify_props: Any | None = None,
+    ):
         """Convert a bot into a user
 
         bot_user_id: Bot user ID
@@ -142,4 +182,18 @@ class Bots(Base):
         `Read in Mattermost API docs (bots - ConvertBotToUser) <https://api.mattermost.com/#tag/bots/operation/ConvertBotToUser>`_
 
         """
-        return self.client.post(f"/api/v4/bots/{bot_user_id}/convert_to_user", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "email": email,
+            "username": username,
+            "password": password,
+            "first_name": first_name,
+            "last_name": last_name,
+            "nickname": nickname,
+            "locale": locale,
+            "position": position,
+            "props": props,
+            "notify_props": notify_props,
+        }
+        return self.client.post(
+            f"/api/v4/bots/{bot_user_id}/convert_to_user", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )

--- a/src/mattermostautodriver/endpoints/bots.py
+++ b/src/mattermostautodriver/endpoints/bots.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Bots(Base):
@@ -129,7 +129,7 @@ class Bots(Base):
         """
         return self.client.get(f"/api/v4/bots/{bot_user_id}/icon")
 
-    def set_bot_icon_image(self, bot_user_id: str, image: str):
+    def set_bot_icon_image(self, bot_user_id: str, image: BinaryIO):
         """Set bot's LHS icon image
 
         bot_user_id: Bot user ID

--- a/src/mattermostautodriver/endpoints/brand.py
+++ b/src/mattermostautodriver/endpoints/brand.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Brand(Base):
@@ -10,7 +11,7 @@ class Brand(Base):
         """
         return self.client.get("""/api/v4/brand/image""")
 
-    def upload_brand_image(self, files, data=None):
+    def upload_brand_image(self, image: str):
         """Upload brand image
 
         image: The image to be uploaded
@@ -18,7 +19,8 @@ class Brand(Base):
         `Read in Mattermost API docs (brand - UploadBrandImage) <https://api.mattermost.com/#tag/brand/operation/UploadBrandImage>`_
 
         """
-        return self.client.post("""/api/v4/brand/image""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"image": image}
+        return self.client.post("""/api/v4/brand/image""", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def delete_brand_image(self):
         """Delete current brand image

--- a/src/mattermostautodriver/endpoints/brand.py
+++ b/src/mattermostautodriver/endpoints/brand.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Brand(Base):
@@ -11,7 +11,7 @@ class Brand(Base):
         """
         return self.client.get("""/api/v4/brand/image""")
 
-    def upload_brand_image(self, image: str):
+    def upload_brand_image(self, image: BinaryIO):
         """Upload brand image
 
         image: The image to be uploaded

--- a/src/mattermostautodriver/endpoints/channels.py
+++ b/src/mattermostautodriver/endpoints/channels.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Channels(Base):

--- a/src/mattermostautodriver/endpoints/channels.py
+++ b/src/mattermostautodriver/endpoints/channels.py
@@ -631,3 +631,13 @@ class Channels(Base):
 
         """
         return self.client.delete(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories/{category_id}")
+
+    def get_channel_access_control_attributes(self, channel_id):
+        """Get access control attributes for a channel
+
+        channel_id: The ID of the channel.
+
+        `Read in Mattermost API docs (channels - GetChannelAccessControlAttributes) <https://api.mattermost.com/#tag/channels/operation/GetChannelAccessControlAttributes>`_
+
+        """
+        return self.client.get(f"/api/v4/channels/{channel_id}/access_control/attributes")

--- a/src/mattermostautodriver/endpoints/channels.py
+++ b/src/mattermostautodriver/endpoints/channels.py
@@ -1,9 +1,19 @@
 from .base import Base
+from typing import Any
 
 
 class Channels(Base):
 
-    def get_all_channels(self, params=None):
+    def get_all_channels(
+        self,
+        not_associated_to_group: str | None = None,
+        page: int | None = 0,
+        per_page: int | None = 0,
+        exclude_default_channels: bool | None = False,
+        include_deleted: bool | None = False,
+        include_total_count: bool | None = False,
+        exclude_policy_constrained: bool | None = False,
+    ):
         """Get a list of all channels
 
         not_associated_to_group: A group id to exclude channels that are associated with that group via GroupChannel records. This can also be left blank with ``not_associated_to_group=``.
@@ -18,9 +28,26 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetAllChannels) <https://api.mattermost.com/#tag/channels/operation/GetAllChannels>`_
 
         """
-        return self.client.get("""/api/v4/channels""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "not_associated_to_group": not_associated_to_group,
+            "page": page,
+            "per_page": per_page,
+            "exclude_default_channels": exclude_default_channels,
+            "include_deleted": include_deleted,
+            "include_total_count": include_total_count,
+            "exclude_policy_constrained": exclude_policy_constrained,
+        }
+        return self.client.get("""/api/v4/channels""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_channel(self, options):
+    def create_channel(
+        self,
+        team_id: str,
+        name: str,
+        display_name: str,
+        type: str,
+        purpose: str | None = None,
+        header: str | None = None,
+    ):
         """Create a channel
 
         team_id: The team ID of the team to create the channel on
@@ -33,23 +60,47 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - CreateChannel) <https://api.mattermost.com/#tag/channels/operation/CreateChannel>`_
 
         """
-        return self.client.post("""/api/v4/channels""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "name": name,
+            "display_name": display_name,
+            "purpose": purpose,
+            "header": header,
+            "type": type,
+        }
+        return self.client.post("""/api/v4/channels""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_direct_channel(self, options):
+    def create_direct_channel(self, options: list[str]):
         """Create a direct message channel
         `Read in Mattermost API docs (channels - CreateDirectChannel) <https://api.mattermost.com/#tag/channels/operation/CreateDirectChannel>`_
 
         """
         return self.client.post("""/api/v4/channels/direct""", options=options)
 
-    def create_group_channel(self, options):
+    def create_group_channel(self, options: list[str]):
         """Create a group message channel
         `Read in Mattermost API docs (channels - CreateGroupChannel) <https://api.mattermost.com/#tag/channels/operation/CreateGroupChannel>`_
 
         """
         return self.client.post("""/api/v4/channels/group""", options=options)
 
-    def search_all_channels(self, options):
+    def search_all_channels(
+        self,
+        term: str,
+        not_associated_to_group: str | None = None,
+        exclude_default_channels: bool | None = None,
+        team_ids: list[str] | None = None,
+        group_constrained: bool | None = None,
+        exclude_group_constrained: bool | None = None,
+        public: bool | None = None,
+        private: bool | None = None,
+        deleted: bool | None = None,
+        page: str | None = None,
+        per_page: str | None = None,
+        exclude_policy_constrained: bool | None = False,
+        include_search_by_id: bool | None = False,
+        exclude_remote: bool | None = False,
+    ):
         """Search all private and open type channels across all teams
 
         term: The string to search in the channel name, display name, and purpose.
@@ -94,9 +145,25 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - SearchAllChannels) <https://api.mattermost.com/#tag/channels/operation/SearchAllChannels>`_
 
         """
-        return self.client.post("""/api/v4/channels/search""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "term": term,
+            "not_associated_to_group": not_associated_to_group,
+            "exclude_default_channels": exclude_default_channels,
+            "team_ids": team_ids,
+            "group_constrained": group_constrained,
+            "exclude_group_constrained": exclude_group_constrained,
+            "public": public,
+            "private": private,
+            "deleted": deleted,
+            "page": page,
+            "per_page": per_page,
+            "exclude_policy_constrained": exclude_policy_constrained,
+            "include_search_by_id": include_search_by_id,
+            "exclude_remote": exclude_remote,
+        }
+        return self.client.post("""/api/v4/channels/search""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def search_group_channels(self, options):
+    def search_group_channels(self, term: str):
         """Search Group Channels
 
         term: The search term to match against the members' usernames of the group channels
@@ -104,9 +171,10 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - SearchGroupChannels) <https://api.mattermost.com/#tag/channels/operation/SearchGroupChannels>`_
 
         """
-        return self.client.post("""/api/v4/channels/group/search""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"term": term}
+        return self.client.post("""/api/v4/channels/group/search""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_public_channels_by_ids_for_team(self, team_id, options):
+    def get_public_channels_by_ids_for_team(self, team_id: str, options: list[str]):
         """Get a list of channels by ids
 
         team_id: Team GUID
@@ -116,7 +184,7 @@ class Channels(Base):
         """
         return self.client.post(f"/api/v4/teams/{team_id}/channels/ids", options=options)
 
-    def get_channel_members_timezones(self, channel_id):
+    def get_channel_members_timezones(self, channel_id: str):
         """Get timezones in a channel
 
         channel_id: Channel GUID
@@ -126,7 +194,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}/timezones")
 
-    def get_channel(self, channel_id):
+    def get_channel(self, channel_id: str):
         """Get a channel
 
         channel_id: Channel GUID
@@ -136,7 +204,15 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}")
 
-    def update_channel(self, channel_id, options):
+    def update_channel(
+        self,
+        channel_id: str,
+        id: str,
+        name: str | None = None,
+        display_name: str | None = None,
+        purpose: str | None = None,
+        header: str | None = None,
+    ):
         """Update a channel
 
         channel_id: Channel GUID
@@ -149,9 +225,16 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - UpdateChannel) <https://api.mattermost.com/#tag/channels/operation/UpdateChannel>`_
 
         """
-        return self.client.put(f"/api/v4/channels/{channel_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "name": name,
+            "display_name": display_name,
+            "purpose": purpose,
+            "header": header,
+        }
+        return self.client.put(f"/api/v4/channels/{channel_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def delete_channel(self, channel_id):
+    def delete_channel(self, channel_id: str):
         """Delete a channel
 
         channel_id: Channel GUID
@@ -161,7 +244,14 @@ class Channels(Base):
         """
         return self.client.delete(f"/api/v4/channels/{channel_id}")
 
-    def patch_channel(self, channel_id, options):
+    def patch_channel(
+        self,
+        channel_id: str,
+        name: str | None = None,
+        display_name: str | None = None,
+        purpose: str | None = None,
+        header: str | None = None,
+    ):
         """Patch a channel
 
         channel_id: Channel GUID
@@ -173,9 +263,15 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - PatchChannel) <https://api.mattermost.com/#tag/channels/operation/PatchChannel>`_
 
         """
-        return self.client.put(f"/api/v4/channels/{channel_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "name": name,
+            "display_name": display_name,
+            "purpose": purpose,
+            "header": header,
+        }
+        return self.client.put(f"/api/v4/channels/{channel_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_channel_privacy(self, channel_id, options):
+    def update_channel_privacy(self, channel_id: str, privacy: str):
         """Update channel's privacy
 
         channel_id: Channel GUID
@@ -184,9 +280,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - UpdateChannelPrivacy) <https://api.mattermost.com/#tag/channels/operation/UpdateChannelPrivacy>`_
 
         """
-        return self.client.put(f"/api/v4/channels/{channel_id}/privacy", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"privacy": privacy}
+        return self.client.put(
+            f"/api/v4/channels/{channel_id}/privacy", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def restore_channel(self, channel_id):
+    def restore_channel(self, channel_id: str):
         """Restore a channel
 
         channel_id: Channel GUID
@@ -196,7 +295,7 @@ class Channels(Base):
         """
         return self.client.post(f"/api/v4/channels/{channel_id}/restore")
 
-    def move_channel(self, channel_id, options):
+    def move_channel(self, channel_id: str, team_id: str, force: bool | None = None):
         """Move a channel
 
         channel_id: Channel GUID
@@ -206,9 +305,10 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - MoveChannel) <https://api.mattermost.com/#tag/channels/operation/MoveChannel>`_
 
         """
-        return self.client.post(f"/api/v4/channels/{channel_id}/move", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id, "force": force}
+        return self.client.post(f"/api/v4/channels/{channel_id}/move", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_channel_stats(self, channel_id):
+    def get_channel_stats(self, channel_id: str):
         """Get channel statistics
 
         channel_id: Channel GUID
@@ -218,7 +318,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}/stats")
 
-    def get_pinned_posts(self, channel_id):
+    def get_pinned_posts(self, channel_id: str):
         """Get a channel's pinned posts
 
         channel_id: Channel GUID
@@ -228,7 +328,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}/pinned")
 
-    def get_public_channels_for_team(self, team_id, params=None):
+    def get_public_channels_for_team(self, team_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get public channels
 
         team_id: Team GUID
@@ -238,9 +338,10 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetPublicChannelsForTeam) <https://api.mattermost.com/#tag/channels/operation/GetPublicChannelsForTeam>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/teams/{team_id}/channels", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_private_channels_for_team(self, team_id, params=None):
+    def get_private_channels_for_team(self, team_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get private channels
 
         team_id: Team GUID
@@ -250,9 +351,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetPrivateChannelsForTeam) <https://api.mattermost.com/#tag/channels/operation/GetPrivateChannelsForTeam>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/channels/private", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/channels/private", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_deleted_channels_for_team(self, team_id, params=None):
+    def get_deleted_channels_for_team(self, team_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get deleted channels
 
         team_id: Team GUID
@@ -262,9 +366,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetDeletedChannelsForTeam) <https://api.mattermost.com/#tag/channels/operation/GetDeletedChannelsForTeam>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/channels/deleted", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/channels/deleted", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def autocomplete_channels_for_team(self, team_id, params=None):
+    def autocomplete_channels_for_team(self, team_id: str, name: str):
         """Autocomplete channels
 
         team_id: Team GUID
@@ -273,9 +380,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - AutocompleteChannelsForTeam) <https://api.mattermost.com/#tag/channels/operation/AutocompleteChannelsForTeam>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/channels/autocomplete", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/channels/autocomplete", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def autocomplete_channels_for_team_for_search(self, team_id, params=None):
+    def autocomplete_channels_for_team_for_search(self, team_id: str, name: str):
         """Autocomplete channels for search
 
         team_id: Team GUID
@@ -284,9 +394,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - AutocompleteChannelsForTeamForSearch) <https://api.mattermost.com/#tag/channels/operation/AutocompleteChannelsForTeamForSearch>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/channels/search_autocomplete", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/channels/search_autocomplete", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def search_channels(self, team_id, options):
+    def search_channels(self, team_id: str, term: str):
         """Search channels
 
         team_id: Team GUID
@@ -295,9 +408,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - SearchChannels) <https://api.mattermost.com/#tag/channels/operation/SearchChannels>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/channels/search", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"term": term}
+        return self.client.post(
+            f"/api/v4/teams/{team_id}/channels/search", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def search_archived_channels(self, team_id, options):
+    def search_archived_channels(self, team_id: str, term: str):
         """Search archived channels
 
         team_id: Team GUID
@@ -306,9 +422,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - SearchArchivedChannels) <https://api.mattermost.com/#tag/channels/operation/SearchArchivedChannels>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/channels/search_archived", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"term": term}
+        return self.client.post(
+            f"/api/v4/teams/{team_id}/channels/search_archived", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_by_name(self, team_id, channel_name, params=None):
+    def get_channel_by_name(self, team_id: str, channel_name: str, include_deleted: bool | None = False):
         """Get a channel by name
 
         team_id: Team GUID
@@ -318,9 +437,14 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetChannelByName) <https://api.mattermost.com/#tag/channels/operation/GetChannelByName>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/channels/name/{channel_name}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_deleted": include_deleted}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/channels/name/{channel_name}", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_by_name_for_team_name(self, team_name, channel_name, params=None):
+    def get_channel_by_name_for_team_name(
+        self, team_name: str, channel_name: str, include_deleted: bool | None = False
+    ):
         """Get a channel by name and team name
 
         team_name: Team Name
@@ -330,9 +454,13 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetChannelByNameForTeamName) <https://api.mattermost.com/#tag/channels/operation/GetChannelByNameForTeamName>`_
 
         """
-        return self.client.get(f"/api/v4/teams/name/{team_name}/channels/name/{channel_name}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_deleted": include_deleted}
+        return self.client.get(
+            f"/api/v4/teams/name/{team_name}/channels/name/{channel_name}",
+            params=params_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def get_channel_members(self, channel_id, params=None):
+    def get_channel_members(self, channel_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get channel members
 
         channel_id: Channel GUID
@@ -342,9 +470,16 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetChannelMembers) <https://api.mattermost.com/#tag/channels/operation/GetChannelMembers>`_
 
         """
-        return self.client.get(f"/api/v4/channels/{channel_id}/members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/channels/{channel_id}/members", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def add_channel_member(self, channel_id, options):
+    def add_channel_member(
+        self,
+        channel_id: str,
+        user_id: str | None = None,
+        user_ids: list[str] | None = None,
+        post_root_id: str | None = None,
+    ):
         """Add user(s) to channel
 
         channel_id: The channel ID
@@ -355,9 +490,16 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - AddChannelMember) <https://api.mattermost.com/#tag/channels/operation/AddChannelMember>`_
 
         """
-        return self.client.post(f"/api/v4/channels/{channel_id}/members", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "user_id": user_id,
+            "user_ids": user_ids,
+            "post_root_id": post_root_id,
+        }
+        return self.client.post(
+            f"/api/v4/channels/{channel_id}/members", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_members_by_ids(self, channel_id, options):
+    def get_channel_members_by_ids(self, channel_id: str, options: list[str]):
         """Get channel members by ids
 
         channel_id: Channel GUID
@@ -367,7 +509,7 @@ class Channels(Base):
         """
         return self.client.post(f"/api/v4/channels/{channel_id}/members/ids", options=options)
 
-    def get_channel_member(self, channel_id, user_id):
+    def get_channel_member(self, channel_id: str, user_id: str):
         """Get channel member
 
         channel_id: Channel GUID
@@ -378,7 +520,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}/members/{user_id}")
 
-    def remove_user_from_channel(self, channel_id, user_id):
+    def remove_user_from_channel(self, channel_id: str, user_id: str):
         """Remove user from channel
 
         channel_id: Channel GUID
@@ -389,7 +531,7 @@ class Channels(Base):
         """
         return self.client.delete(f"/api/v4/channels/{channel_id}/members/{user_id}")
 
-    def update_channel_roles(self, channel_id, user_id, options):
+    def update_channel_roles(self, channel_id: str, user_id: str, roles: str):
         """Update channel roles
 
         channel_id: Channel GUID
@@ -399,9 +541,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - UpdateChannelRoles) <https://api.mattermost.com/#tag/channels/operation/UpdateChannelRoles>`_
 
         """
-        return self.client.put(f"/api/v4/channels/{channel_id}/members/{user_id}/roles", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"roles": roles}
+        return self.client.put(
+            f"/api/v4/channels/{channel_id}/members/{user_id}/roles", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_channel_member_scheme_roles(self, channel_id, user_id, options):
+    def update_channel_member_scheme_roles(self, channel_id: str, user_id: str, scheme_admin: bool, scheme_user: bool):
         """Update the scheme-derived roles of a channel member.
 
         channel_id: Channel GUID
@@ -412,9 +557,13 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - UpdateChannelMemberSchemeRoles) <https://api.mattermost.com/#tag/channels/operation/UpdateChannelMemberSchemeRoles>`_
 
         """
-        return self.client.put(f"/api/v4/channels/{channel_id}/members/{user_id}/schemeRoles", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"scheme_admin": scheme_admin, "scheme_user": scheme_user}
+        return self.client.put(
+            f"/api/v4/channels/{channel_id}/members/{user_id}/schemeRoles",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def update_channel_notify_props(self, channel_id, user_id, options):
+    def update_channel_notify_props(self, channel_id: str, user_id: str, options: Any):
         """Update channel notifications
 
         channel_id: Channel GUID
@@ -425,7 +574,7 @@ class Channels(Base):
         """
         return self.client.put(f"/api/v4/channels/{channel_id}/members/{user_id}/notify_props", options=options)
 
-    def view_channel(self, user_id, options):
+    def view_channel(self, user_id: str, channel_id: str, prev_channel_id: str | None = None):
         """View channel
 
         user_id: User ID to perform the view action for
@@ -435,9 +584,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - ViewChannel) <https://api.mattermost.com/#tag/channels/operation/ViewChannel>`_
 
         """
-        return self.client.post(f"/api/v4/channels/members/{user_id}/view", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_id": channel_id, "prev_channel_id": prev_channel_id}
+        return self.client.post(
+            f"/api/v4/channels/members/{user_id}/view", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_members_for_user(self, user_id, team_id):
+    def get_channel_members_for_user(self, user_id: str, team_id: str):
         """Get channel memberships and roles for a user
 
         user_id: User GUID
@@ -448,7 +600,9 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/channels/members")
 
-    def get_channels_for_team_for_user(self, user_id, team_id, params=None):
+    def get_channels_for_team_for_user(
+        self, user_id: str, team_id: str, include_deleted: bool | None = False, last_delete_at: int | None = 0
+    ):
         """Get channels for user
 
         user_id: User GUID
@@ -459,9 +613,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetChannelsForTeamForUser) <https://api.mattermost.com/#tag/channels/operation/GetChannelsForTeamForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_deleted": include_deleted, "last_delete_at": last_delete_at}
+        return self.client.get(
+            f"/api/v4/users/{user_id}/teams/{team_id}/channels", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channels_for_user(self, user_id, params=None):
+    def get_channels_for_user(self, user_id: str, last_delete_at: int | None = 0, include_deleted: bool | None = False):
         """Get all channels from all teams
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -471,9 +628,10 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetChannelsForUser) <https://api.mattermost.com/#tag/channels/operation/GetChannelsForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"last_delete_at": last_delete_at, "include_deleted": include_deleted}
+        return self.client.get(f"/api/v4/users/{user_id}/channels", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_channel_unread(self, user_id, channel_id):
+    def get_channel_unread(self, user_id: str, channel_id: str):
         """Get unread messages
 
         user_id: User GUID
@@ -484,7 +642,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/channels/{channel_id}/unread")
 
-    def update_channel_scheme(self, channel_id, options):
+    def update_channel_scheme(self, channel_id: str, scheme_id: str):
         """Set a channel's scheme
 
         channel_id: Channel GUID
@@ -493,9 +651,14 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - UpdateChannelScheme) <https://api.mattermost.com/#tag/channels/operation/UpdateChannelScheme>`_
 
         """
-        return self.client.put(f"/api/v4/channels/{channel_id}/scheme", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"scheme_id": scheme_id}
+        return self.client.put(
+            f"/api/v4/channels/{channel_id}/scheme", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def channel_members_minus_group_members(self, channel_id, params=None):
+    def channel_members_minus_group_members(
+        self, channel_id: str, group_ids: str = "", page: int | None = 0, per_page: int | None = 0
+    ):
         """Channel members minus group members.
 
         channel_id: Channel GUID
@@ -506,9 +669,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - ChannelMembersMinusGroupMembers) <https://api.mattermost.com/#tag/channels/operation/ChannelMembersMinusGroupMembers>`_
 
         """
-        return self.client.get(f"/api/v4/channels/{channel_id}/members_minus_group_members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"group_ids": group_ids, "page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/channels/{channel_id}/members_minus_group_members", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_member_counts_by_group(self, channel_id, params=None):
+    def get_channel_member_counts_by_group(self, channel_id: str, include_timezones: bool | None = False):
         """Channel members counts for each group that has atleast one member in the channel
 
         channel_id: Channel GUID
@@ -517,9 +683,12 @@ class Channels(Base):
         `Read in Mattermost API docs (channels - GetChannelMemberCountsByGroup) <https://api.mattermost.com/#tag/channels/operation/GetChannelMemberCountsByGroup>`_
 
         """
-        return self.client.get(f"/api/v4/channels/{channel_id}/member_counts_by_group", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_timezones": include_timezones}
+        return self.client.get(
+            f"/api/v4/channels/{channel_id}/member_counts_by_group", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_moderations(self, channel_id):
+    def get_channel_moderations(self, channel_id: str):
         """Get information about channel's moderation.
 
         channel_id: Channel GUID
@@ -529,7 +698,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/channels/{channel_id}/moderations")
 
-    def patch_channel_moderations(self, channel_id, options):
+    def patch_channel_moderations(self, channel_id: str, options: Any):
         """Update a channel's moderation settings.
 
         channel_id: Channel GUID
@@ -539,7 +708,7 @@ class Channels(Base):
         """
         return self.client.put(f"/api/v4/channels/{channel_id}/moderations/patch", options=options)
 
-    def get_sidebar_categories_for_team_for_user(self, team_id, user_id):
+    def get_sidebar_categories_for_team_for_user(self, team_id: str, user_id: str):
         """Get user's sidebar categories
 
         team_id: Team GUID
@@ -550,7 +719,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories")
 
-    def create_sidebar_category_for_team_for_user(self, team_id, user_id, options):
+    def create_sidebar_category_for_team_for_user(self, team_id: str, user_id: str, options: Any):
         """Create user's sidebar category
 
         team_id: Team GUID
@@ -561,7 +730,7 @@ class Channels(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories", options=options)
 
-    def update_sidebar_categories_for_team_for_user(self, team_id, user_id, options):
+    def update_sidebar_categories_for_team_for_user(self, team_id: str, user_id: str, options: list[Any]):
         """Update user's sidebar categories
 
         team_id: Team GUID
@@ -572,7 +741,7 @@ class Channels(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories", options=options)
 
-    def get_sidebar_category_order_for_team_for_user(self, team_id, user_id):
+    def get_sidebar_category_order_for_team_for_user(self, team_id: str, user_id: str):
         """Get user's sidebar category order
 
         team_id: Team GUID
@@ -583,7 +752,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories/order")
 
-    def update_sidebar_category_order_for_team_for_user(self, team_id, user_id, options):
+    def update_sidebar_category_order_for_team_for_user(self, team_id: str, user_id: str, options: list[str]):
         """Update user's sidebar category order
 
         team_id: Team GUID
@@ -594,7 +763,7 @@ class Channels(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories/order", options=options)
 
-    def get_sidebar_category_for_team_for_user(self, team_id, user_id, category_id):
+    def get_sidebar_category_for_team_for_user(self, team_id: str, user_id: str, category_id: str):
         """Get sidebar category
 
         team_id: Team GUID
@@ -606,7 +775,7 @@ class Channels(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories/{category_id}")
 
-    def update_sidebar_category_for_team_for_user(self, team_id, user_id, category_id, options):
+    def update_sidebar_category_for_team_for_user(self, team_id: str, user_id: str, category_id: str, options: Any):
         """Update sidebar category
 
         team_id: Team GUID
@@ -620,7 +789,7 @@ class Channels(Base):
             f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories/{category_id}", options=options
         )
 
-    def remove_sidebar_category_for_team_for_user(self, team_id, user_id, category_id):
+    def remove_sidebar_category_for_team_for_user(self, team_id: str, user_id: str, category_id: str):
         """Delete sidebar category
 
         team_id: Team GUID
@@ -632,7 +801,7 @@ class Channels(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}/teams/{team_id}/channels/categories/{category_id}")
 
-    def get_channel_access_control_attributes(self, channel_id):
+    def get_channel_access_control_attributes(self, channel_id: str):
         """Get access control attributes for a channel
 
         channel_id: The ID of the channel.

--- a/src/mattermostautodriver/endpoints/cloud.py
+++ b/src/mattermostautodriver/endpoints/cloud.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Cloud(Base):
@@ -24,7 +25,7 @@ class Cloud(Base):
         """
         return self.client.post("""/api/v4/cloud/payment""")
 
-    def confirm_customer_payment(self, data=None):
+    def confirm_customer_payment(self, stripe_setup_intent_id: str | None = None):
         """Completes the payment setup intent
 
         stripe_setup_intent_id:
@@ -32,7 +33,8 @@ class Cloud(Base):
         `Read in Mattermost API docs (cloud - ConfirmCustomerPayment) <https://api.mattermost.com/#tag/cloud/operation/ConfirmCustomerPayment>`_
 
         """
-        return self.client.post("""/api/v4/cloud/payment/confirm""", data=data)
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {"stripe_setup_intent_id": stripe_setup_intent_id}
+        return self.client.post("""/api/v4/cloud/payment/confirm""", data=data_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_cloud_customer(self):
         """Get cloud customer
@@ -41,7 +43,14 @@ class Cloud(Base):
         """
         return self.client.get("""/api/v4/cloud/customer""")
 
-    def update_cloud_customer(self, options):
+    def update_cloud_customer(
+        self,
+        name: str | None = None,
+        email: str | None = None,
+        contact_first_name: str | None = None,
+        contact_last_name: str | None = None,
+        num_employees: str | None = None,
+    ):
         """Update cloud customer
 
         name:
@@ -53,9 +62,16 @@ class Cloud(Base):
         `Read in Mattermost API docs (cloud - UpdateCloudCustomer) <https://api.mattermost.com/#tag/cloud/operation/UpdateCloudCustomer>`_
 
         """
-        return self.client.put("""/api/v4/cloud/customer""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "name": name,
+            "email": email,
+            "contact_first_name": contact_first_name,
+            "contact_last_name": contact_last_name,
+            "num_employees": num_employees,
+        }
+        return self.client.put("""/api/v4/cloud/customer""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_cloud_customer_address(self, options):
+    def update_cloud_customer_address(self, options: Any):
         """Update cloud customer address
         `Read in Mattermost API docs (cloud - UpdateCloudCustomerAddress) <https://api.mattermost.com/#tag/cloud/operation/UpdateCloudCustomerAddress>`_
 
@@ -83,7 +99,7 @@ class Cloud(Base):
         """
         return self.client.get("""/api/v4/cloud/subscription/invoices""")
 
-    def get_invoice_for_subscription_as_pdf(self, invoice_id):
+    def get_invoice_for_subscription_as_pdf(self, invoice_id: str):
         """Get cloud invoice PDF
 
         invoice_id: Invoice ID

--- a/src/mattermostautodriver/endpoints/cloud.py
+++ b/src/mattermostautodriver/endpoints/cloud.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Cloud(Base):

--- a/src/mattermostautodriver/endpoints/cluster.py
+++ b/src/mattermostautodriver/endpoints/cluster.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Cluster(Base):

--- a/src/mattermostautodriver/endpoints/cluster.py
+++ b/src/mattermostautodriver/endpoints/cluster.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Cluster(Base):

--- a/src/mattermostautodriver/endpoints/commands.py
+++ b/src/mattermostautodriver/endpoints/commands.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Commands(Base):
 
-    def create_command(self, options):
+    def create_command(self, team_id: str, method: str, trigger: str, url: str):
         """Create a command
 
         team_id: Team ID to where the command should be created
@@ -14,9 +15,15 @@ class Commands(Base):
         `Read in Mattermost API docs (commands - CreateCommand) <https://api.mattermost.com/#tag/commands/operation/CreateCommand>`_
 
         """
-        return self.client.post("""/api/v4/commands""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "method": method,
+            "trigger": trigger,
+            "url": url,
+        }
+        return self.client.post("""/api/v4/commands""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def list_commands(self, params=None):
+    def list_commands(self, team_id: str | None = None, custom_only: bool | None = False):
         """List commands for a team
 
         team_id: The team id.
@@ -27,9 +34,10 @@ class Commands(Base):
         `Read in Mattermost API docs (commands - ListCommands) <https://api.mattermost.com/#tag/commands/operation/ListCommands>`_
 
         """
-        return self.client.get("""/api/v4/commands""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id, "custom_only": custom_only}
+        return self.client.get("""/api/v4/commands""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def list_autocomplete_commands(self, team_id):
+    def list_autocomplete_commands(self, team_id: str):
         """List autocomplete commands
 
         team_id: Team GUID
@@ -39,7 +47,7 @@ class Commands(Base):
         """
         return self.client.get(f"/api/v4/teams/{team_id}/commands/autocomplete")
 
-    def list_command_autocomplete_suggestions(self, team_id, params=None):
+    def list_command_autocomplete_suggestions(self, team_id: str, user_input: str):
         """List commands' autocomplete data
 
         team_id: Team GUID
@@ -48,9 +56,12 @@ class Commands(Base):
         `Read in Mattermost API docs (commands - ListCommandAutocompleteSuggestions) <https://api.mattermost.com/#tag/commands/operation/ListCommandAutocompleteSuggestions>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/commands/autocomplete_suggestions", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"user_input": user_input}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/commands/autocomplete_suggestions", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_command_by_id(self, command_id):
+    def get_command_by_id(self, command_id: str):
         """Get a command
 
         command_id: ID of the command to get
@@ -60,7 +71,7 @@ class Commands(Base):
         """
         return self.client.get(f"/api/v4/commands/{command_id}")
 
-    def update_command(self, command_id, options):
+    def update_command(self, command_id: str, options: Any):
         """Update a command
 
         command_id: ID of the command to update
@@ -70,7 +81,7 @@ class Commands(Base):
         """
         return self.client.put(f"/api/v4/commands/{command_id}", options=options)
 
-    def delete_command(self, command_id):
+    def delete_command(self, command_id: str):
         """Delete a command
 
         command_id: ID of the command to delete
@@ -80,7 +91,7 @@ class Commands(Base):
         """
         return self.client.delete(f"/api/v4/commands/{command_id}")
 
-    def move_command(self, command_id, options):
+    def move_command(self, command_id: str, team_id: str | None = None):
         """Move a command
 
         command_id: ID of the command to move
@@ -89,9 +100,10 @@ class Commands(Base):
         `Read in Mattermost API docs (commands - MoveCommand) <https://api.mattermost.com/#tag/commands/operation/MoveCommand>`_
 
         """
-        return self.client.put(f"/api/v4/commands/{command_id}/move", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.put(f"/api/v4/commands/{command_id}/move", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def regen_command_token(self, command_id):
+    def regen_command_token(self, command_id: str):
         """Generate a new token
 
         command_id: ID of the command to generate the new token
@@ -101,7 +113,7 @@ class Commands(Base):
         """
         return self.client.put(f"/api/v4/commands/{command_id}/regen_token")
 
-    def execute_command(self, options):
+    def execute_command(self, channel_id: str, command: str):
         """Execute a command
 
         channel_id: Channel Id where the command will execute
@@ -110,4 +122,5 @@ class Commands(Base):
         `Read in Mattermost API docs (commands - ExecuteCommand) <https://api.mattermost.com/#tag/commands/operation/ExecuteCommand>`_
 
         """
-        return self.client.post("""/api/v4/commands/execute""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_id": channel_id, "command": command}
+        return self.client.post("""/api/v4/commands/execute""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/commands.py
+++ b/src/mattermostautodriver/endpoints/commands.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Commands(Base):

--- a/src/mattermostautodriver/endpoints/compliance.py
+++ b/src/mattermostautodriver/endpoints/compliance.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Compliance(Base):
@@ -10,7 +11,7 @@ class Compliance(Base):
         """
         return self.client.post("""/api/v4/compliance/reports""")
 
-    def get_compliance_reports(self, params=None):
+    def get_compliance_reports(self, page: int | None = 0, per_page: int | None = 60):
         """Get reports
 
         page: The page to select.
@@ -19,9 +20,10 @@ class Compliance(Base):
         `Read in Mattermost API docs (compliance - GetComplianceReports) <https://api.mattermost.com/#tag/compliance/operation/GetComplianceReports>`_
 
         """
-        return self.client.get("""/api/v4/compliance/reports""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/compliance/reports""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_compliance_report(self, report_id):
+    def get_compliance_report(self, report_id: str):
         """Get a report
 
         report_id: Compliance report GUID
@@ -31,7 +33,7 @@ class Compliance(Base):
         """
         return self.client.get(f"/api/v4/compliance/reports/{report_id}")
 
-    def download_compliance_report(self, report_id):
+    def download_compliance_report(self, report_id: str):
         """Download a report
 
         report_id: Compliance report GUID

--- a/src/mattermostautodriver/endpoints/compliance.py
+++ b/src/mattermostautodriver/endpoints/compliance.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Compliance(Base):

--- a/src/mattermostautodriver/endpoints/custom_profile_attributes.py
+++ b/src/mattermostautodriver/endpoints/custom_profile_attributes.py
@@ -1,0 +1,70 @@
+from .base import Base
+
+
+class CustomProfileAttributes(Base):
+
+    def list_all_cpa_fields(self):
+        """List all the Custom Profile Attributes fields
+        `Read in Mattermost API docs (custom_profile_attributes - ListAllCPAFields) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/ListAllCPAFields>`_
+
+        """
+        return self.client.get("""/api/v4/custom_profile_attributes/fields""")
+
+    def create_cpa_field(self, options=None):
+        """Create a Custom Profile Attribute field
+
+        name:
+        type:
+        attrs:
+
+        `Read in Mattermost API docs (custom_profile_attributes - CreateCPAField) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/CreateCPAField>`_
+
+        """
+        return self.client.post("""/api/v4/custom_profile_attributes/fields""", options=options)
+
+    def patch_cpa_field(self, field_id, options):
+        """Patch a Custom Profile Attribute field
+
+        field_id: Custom Profile Attribute field GUID
+        name:
+        type:
+        attrs:
+
+        `Read in Mattermost API docs (custom_profile_attributes - PatchCPAField) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/PatchCPAField>`_
+
+        """
+        return self.client.patch(f"/api/v4/custom_profile_attributes/fields/{field_id}", options=options)
+
+    def delete_cpa_field(self, field_id):
+        """Delete a Custom Profile Attribute field
+
+        field_id: Custom Profile Attribute field GUID
+
+        `Read in Mattermost API docs (custom_profile_attributes - DeleteCPAField) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/DeleteCPAField>`_
+
+        """
+        return self.client.delete(f"/api/v4/custom_profile_attributes/fields/{field_id}")
+
+    def patch_cpa_values(self, options):
+        """Patch Custom Profile Attribute values
+        `Read in Mattermost API docs (custom_profile_attributes - PatchCPAValues) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/PatchCPAValues>`_
+
+        """
+        return self.client.patch("""/api/v4/custom_profile_attributes/values""", options=options)
+
+    def get_cpa_group(self):
+        """Get Custom Profile Attribute property group data
+        `Read in Mattermost API docs (custom_profile_attributes - GetCPAGroup) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/GetCPAGroup>`_
+
+        """
+        return self.client.get("""/api/v4/custom_profile_attributes/group""")
+
+    def list_cpa_values(self, user_id):
+        """List Custom Profile Attribute values
+
+        user_id: User GUID
+
+        `Read in Mattermost API docs (custom_profile_attributes - ListCPAValues) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/ListCPAValues>`_
+
+        """
+        return self.client.get(f"/api/v4/users/{user_id}/custom_profile_attributes")

--- a/src/mattermostautodriver/endpoints/custom_profile_attributes.py
+++ b/src/mattermostautodriver/endpoints/custom_profile_attributes.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class CustomProfileAttributes(Base):
@@ -10,7 +11,7 @@ class CustomProfileAttributes(Base):
         """
         return self.client.get("""/api/v4/custom_profile_attributes/fields""")
 
-    def create_cpa_field(self, options=None):
+    def create_cpa_field(self, name: str, type: str, attrs: str | None = None):
         """Create a Custom Profile Attribute field
 
         name:
@@ -20,9 +21,14 @@ class CustomProfileAttributes(Base):
         `Read in Mattermost API docs (custom_profile_attributes - CreateCPAField) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/CreateCPAField>`_
 
         """
-        return self.client.post("""/api/v4/custom_profile_attributes/fields""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name, "type": type, "attrs": attrs}
+        return self.client.post(
+            """/api/v4/custom_profile_attributes/fields""", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def patch_cpa_field(self, field_id, options):
+    def patch_cpa_field(
+        self, field_id: str, name: str | None = None, type: str | None = None, attrs: str | None = None
+    ):
         """Patch a Custom Profile Attribute field
 
         field_id: Custom Profile Attribute field GUID
@@ -33,9 +39,12 @@ class CustomProfileAttributes(Base):
         `Read in Mattermost API docs (custom_profile_attributes - PatchCPAField) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/PatchCPAField>`_
 
         """
-        return self.client.patch(f"/api/v4/custom_profile_attributes/fields/{field_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name, "type": type, "attrs": attrs}
+        return self.client.patch(
+            f"/api/v4/custom_profile_attributes/fields/{field_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def delete_cpa_field(self, field_id):
+    def delete_cpa_field(self, field_id: str):
         """Delete a Custom Profile Attribute field
 
         field_id: Custom Profile Attribute field GUID
@@ -45,7 +54,7 @@ class CustomProfileAttributes(Base):
         """
         return self.client.delete(f"/api/v4/custom_profile_attributes/fields/{field_id}")
 
-    def patch_cpa_values(self, options):
+    def patch_cpa_values(self, options: list[dict[str, Any]]):
         """Patch Custom Profile Attribute values
         `Read in Mattermost API docs (custom_profile_attributes - PatchCPAValues) <https://api.mattermost.com/#tag/custom_profile_attributes/operation/PatchCPAValues>`_
 
@@ -59,7 +68,7 @@ class CustomProfileAttributes(Base):
         """
         return self.client.get("""/api/v4/custom_profile_attributes/group""")
 
-    def list_cpa_values(self, user_id):
+    def list_cpa_values(self, user_id: str):
         """List Custom Profile Attribute values
 
         user_id: User GUID

--- a/src/mattermostautodriver/endpoints/custom_profile_attributes.py
+++ b/src/mattermostautodriver/endpoints/custom_profile_attributes.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class CustomProfileAttributes(Base):

--- a/src/mattermostautodriver/endpoints/data_retention.py
+++ b/src/mattermostautodriver/endpoints/data_retention.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class DataRetention(Base):

--- a/src/mattermostautodriver/endpoints/data_retention.py
+++ b/src/mattermostautodriver/endpoints/data_retention.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class DataRetention(Base):
 
-    def get_team_policies_for_user(self, user_id, params=None):
+    def get_team_policies_for_user(self, user_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get the policies which are applied to a user's teams
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -13,9 +14,12 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - GetTeamPoliciesForUser) <https://api.mattermost.com/#tag/data_retention/operation/GetTeamPoliciesForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/data_retention/team_policies", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/users/{user_id}/data_retention/team_policies", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channel_policies_for_user(self, user_id, params=None):
+    def get_channel_policies_for_user(self, user_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get the policies which are applied to a user's channels
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -25,7 +29,10 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - GetChannelPoliciesForUser) <https://api.mattermost.com/#tag/data_retention/operation/GetChannelPoliciesForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/data_retention/channel_policies", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/users/{user_id}/data_retention/channel_policies", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
     def get_data_retention_policy(self):
         """Get the global data retention policy
@@ -41,7 +48,7 @@ class DataRetention(Base):
         """
         return self.client.get("""/api/v4/data_retention/policies_count""")
 
-    def get_data_retention_policies(self, params=None):
+    def get_data_retention_policies(self, page: int | None = 0, per_page: int | None = 60):
         """Get the granular data retention policies
 
         page: The page to select.
@@ -50,16 +57,17 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - GetDataRetentionPolicies) <https://api.mattermost.com/#tag/data_retention/operation/GetDataRetentionPolicies>`_
 
         """
-        return self.client.get("""/api/v4/data_retention/policies""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/data_retention/policies""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_data_retention_policy(self, options):
+    def create_data_retention_policy(self, options: Any):
         """Create a new granular data retention policy
         `Read in Mattermost API docs (data_retention - CreateDataRetentionPolicy) <https://api.mattermost.com/#tag/data_retention/operation/CreateDataRetentionPolicy>`_
 
         """
         return self.client.post("""/api/v4/data_retention/policies""", options=options)
 
-    def get_data_retention_policy_by_id(self, policy_id):
+    def get_data_retention_policy_by_id(self, policy_id: str):
         """Get a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -69,7 +77,7 @@ class DataRetention(Base):
         """
         return self.client.get(f"/api/v4/data_retention/policies/{policy_id}")
 
-    def patch_data_retention_policy(self, policy_id, options):
+    def patch_data_retention_policy(self, policy_id: str, options: Any):
         """Patch a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -79,7 +87,7 @@ class DataRetention(Base):
         """
         return self.client.patch(f"/api/v4/data_retention/policies/{policy_id}", options=options)
 
-    def delete_data_retention_policy(self, policy_id):
+    def delete_data_retention_policy(self, policy_id: str):
         """Delete a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -89,7 +97,7 @@ class DataRetention(Base):
         """
         return self.client.delete(f"/api/v4/data_retention/policies/{policy_id}")
 
-    def get_teams_for_retention_policy(self, policy_id, params=None):
+    def get_teams_for_retention_policy(self, policy_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get the teams for a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -99,9 +107,12 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - GetTeamsForRetentionPolicy) <https://api.mattermost.com/#tag/data_retention/operation/GetTeamsForRetentionPolicy>`_
 
         """
-        return self.client.get(f"/api/v4/data_retention/policies/{policy_id}/teams", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/data_retention/policies/{policy_id}/teams", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def add_teams_to_retention_policy(self, policy_id, options):
+    def add_teams_to_retention_policy(self, policy_id: str, options: list[str]):
         """Add teams to a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -111,7 +122,7 @@ class DataRetention(Base):
         """
         return self.client.post(f"/api/v4/data_retention/policies/{policy_id}/teams", options=options)
 
-    def remove_teams_from_retention_policy(self, policy_id, params):
+    def remove_teams_from_retention_policy(self, policy_id: str, params: list[str]):
         """Delete teams from a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -121,7 +132,7 @@ class DataRetention(Base):
         """
         return self.client.delete(f"/api/v4/data_retention/policies/{policy_id}/teams", params=params)
 
-    def search_teams_for_retention_policy(self, policy_id, options):
+    def search_teams_for_retention_policy(self, policy_id: str, term: str | None = None):
         """Search for the teams in a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -130,9 +141,13 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - SearchTeamsForRetentionPolicy) <https://api.mattermost.com/#tag/data_retention/operation/SearchTeamsForRetentionPolicy>`_
 
         """
-        return self.client.post(f"/api/v4/data_retention/policies/{policy_id}/teams/search", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"term": term}
+        return self.client.post(
+            f"/api/v4/data_retention/policies/{policy_id}/teams/search",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def get_channels_for_retention_policy(self, policy_id, params=None):
+    def get_channels_for_retention_policy(self, policy_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get the channels for a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -142,9 +157,12 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - GetChannelsForRetentionPolicy) <https://api.mattermost.com/#tag/data_retention/operation/GetChannelsForRetentionPolicy>`_
 
         """
-        return self.client.get(f"/api/v4/data_retention/policies/{policy_id}/channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/data_retention/policies/{policy_id}/channels", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def add_channels_to_retention_policy(self, policy_id, options):
+    def add_channels_to_retention_policy(self, policy_id: str, options: list[str]):
         """Add channels to a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -154,7 +172,7 @@ class DataRetention(Base):
         """
         return self.client.post(f"/api/v4/data_retention/policies/{policy_id}/channels", options=options)
 
-    def remove_channels_from_retention_policy(self, policy_id, params):
+    def remove_channels_from_retention_policy(self, policy_id: str, params: list[str]):
         """Delete channels from a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -164,7 +182,15 @@ class DataRetention(Base):
         """
         return self.client.delete(f"/api/v4/data_retention/policies/{policy_id}/channels", params=params)
 
-    def search_channels_for_retention_policy(self, policy_id, options):
+    def search_channels_for_retention_policy(
+        self,
+        policy_id: str,
+        term: str | None = None,
+        team_ids: list[str] | None = None,
+        public: bool | None = None,
+        private: bool | None = None,
+        deleted: bool | None = None,
+    ):
         """Search for the channels in a granular data retention policy
 
         policy_id: The ID of the granular retention policy.
@@ -181,4 +207,14 @@ class DataRetention(Base):
         `Read in Mattermost API docs (data_retention - SearchChannelsForRetentionPolicy) <https://api.mattermost.com/#tag/data_retention/operation/SearchChannelsForRetentionPolicy>`_
 
         """
-        return self.client.post(f"/api/v4/data_retention/policies/{policy_id}/channels/search", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "term": term,
+            "team_ids": team_ids,
+            "public": public,
+            "private": private,
+            "deleted": deleted,
+        }
+        return self.client.post(
+            f"/api/v4/data_retention/policies/{policy_id}/channels/search",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
+        )

--- a/src/mattermostautodriver/endpoints/elasticsearch.py
+++ b/src/mattermostautodriver/endpoints/elasticsearch.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Elasticsearch(Base):

--- a/src/mattermostautodriver/endpoints/elasticsearch.py
+++ b/src/mattermostautodriver/endpoints/elasticsearch.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Elasticsearch(Base):

--- a/src/mattermostautodriver/endpoints/emoji.py
+++ b/src/mattermostautodriver/endpoints/emoji.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Emoji(Base):
 
-    def create_emoji(self, files, data=None):
+    def create_emoji(self, image: str, emoji: str):
         """Create a custom emoji
 
         image: A file to be uploaded
@@ -12,9 +13,15 @@ class Emoji(Base):
         `Read in Mattermost API docs (emoji - CreateEmoji) <https://api.mattermost.com/#tag/emoji/operation/CreateEmoji>`_
 
         """
-        return self.client.post("""/api/v4/emoji""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"image": image}
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {"emoji": emoji}
+        return self.client.post(
+            """/api/v4/emoji""",
+            files=files_71f8b7431cd64fcfa0dabd300d0636d2,
+            data=data_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def get_emoji_list(self, params=None):
+    def get_emoji_list(self, page: int | None = 0, per_page: int | None = 60, sort: str | None = ""):
         """Get a list of custom emoji
 
         page: The page to select.
@@ -24,9 +31,10 @@ class Emoji(Base):
         `Read in Mattermost API docs (emoji - GetEmojiList) <https://api.mattermost.com/#tag/emoji/operation/GetEmojiList>`_
 
         """
-        return self.client.get("""/api/v4/emoji""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page, "sort": sort}
+        return self.client.get("""/api/v4/emoji""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_emoji(self, emoji_id):
+    def get_emoji(self, emoji_id: str):
         """Get a custom emoji
 
         emoji_id: Emoji GUID
@@ -36,7 +44,7 @@ class Emoji(Base):
         """
         return self.client.get(f"/api/v4/emoji/{emoji_id}")
 
-    def delete_emoji(self, emoji_id):
+    def delete_emoji(self, emoji_id: str):
         """Delete a custom emoji
 
         emoji_id: Emoji GUID
@@ -46,7 +54,7 @@ class Emoji(Base):
         """
         return self.client.delete(f"/api/v4/emoji/{emoji_id}")
 
-    def get_emoji_by_name(self, emoji_name):
+    def get_emoji_by_name(self, emoji_name: str):
         """Get a custom emoji by name
 
         emoji_name: Emoji name
@@ -56,7 +64,7 @@ class Emoji(Base):
         """
         return self.client.get(f"/api/v4/emoji/name/{emoji_name}")
 
-    def get_emoji_image(self, emoji_id):
+    def get_emoji_image(self, emoji_id: str):
         """Get custom emoji image
 
         emoji_id: Emoji GUID
@@ -66,7 +74,7 @@ class Emoji(Base):
         """
         return self.client.get(f"/api/v4/emoji/{emoji_id}/image")
 
-    def search_emoji(self, options):
+    def search_emoji(self, term: str, prefix_only: str | None = None):
         """Search custom emoji
 
         term: The term to match against the emoji name.
@@ -75,9 +83,10 @@ class Emoji(Base):
         `Read in Mattermost API docs (emoji - SearchEmoji) <https://api.mattermost.com/#tag/emoji/operation/SearchEmoji>`_
 
         """
-        return self.client.post("""/api/v4/emoji/search""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"term": term, "prefix_only": prefix_only}
+        return self.client.post("""/api/v4/emoji/search""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def autocomplete_emoji(self, params=None):
+    def autocomplete_emoji(self, name: str):
         """Autocomplete custom emoji
 
         name: The emoji name to search.
@@ -85,9 +94,10 @@ class Emoji(Base):
         `Read in Mattermost API docs (emoji - AutocompleteEmoji) <https://api.mattermost.com/#tag/emoji/operation/AutocompleteEmoji>`_
 
         """
-        return self.client.get("""/api/v4/emoji/autocomplete""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name}
+        return self.client.get("""/api/v4/emoji/autocomplete""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_emojis_by_names(self, options):
+    def get_emojis_by_names(self, options: list[str]):
         """Get custom emojis by name
         `Read in Mattermost API docs (emoji - GetEmojisByNames) <https://api.mattermost.com/#tag/emoji/operation/GetEmojisByNames>`_
 

--- a/src/mattermostautodriver/endpoints/emoji.py
+++ b/src/mattermostautodriver/endpoints/emoji.py
@@ -1,10 +1,10 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Emoji(Base):
 
-    def create_emoji(self, image: str, emoji: str):
+    def create_emoji(self, image: BinaryIO, emoji: str):
         """Create a custom emoji
 
         image: A file to be uploaded

--- a/src/mattermostautodriver/endpoints/exports.py
+++ b/src/mattermostautodriver/endpoints/exports.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Exports(Base):
@@ -10,7 +11,7 @@ class Exports(Base):
         """
         return self.client.get("""/api/v4/exports""")
 
-    def download_export(self, export_name):
+    def download_export(self, export_name: str):
         """Download an export file
 
         export_name: The name of the export file to download
@@ -20,7 +21,7 @@ class Exports(Base):
         """
         return self.client.get(f"/api/v4/exports/{export_name}")
 
-    def delete_export(self, export_name):
+    def delete_export(self, export_name: str):
         """Delete an export file
 
         export_name: The name of the export file to delete

--- a/src/mattermostautodriver/endpoints/exports.py
+++ b/src/mattermostautodriver/endpoints/exports.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Exports(Base):

--- a/src/mattermostautodriver/endpoints/files.py
+++ b/src/mattermostautodriver/endpoints/files.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Files(Base):
 
-    def upload_file(self, files, data=None):
+    def upload_file(self, files: str | None = None, channel_id: str | None = None, client_ids: str | None = None):
         """Upload a file
 
         files: A file to be uploaded
@@ -13,9 +14,15 @@ class Files(Base):
         `Read in Mattermost API docs (files - UploadFile) <https://api.mattermost.com/#tag/files/operation/UploadFile>`_
 
         """
-        return self.client.post("""/api/v4/files""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"files": files}
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_id": channel_id, "client_ids": client_ids}
+        return self.client.post(
+            """/api/v4/files""",
+            files=files_71f8b7431cd64fcfa0dabd300d0636d2,
+            data=data_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def get_file(self, file_id):
+    def get_file(self, file_id: str):
         """Get a file
 
         file_id: The ID of the file to get
@@ -25,7 +32,7 @@ class Files(Base):
         """
         return self.client.get(f"/api/v4/files/{file_id}")
 
-    def get_file_thumbnail(self, file_id):
+    def get_file_thumbnail(self, file_id: str):
         """Get a file's thumbnail
 
         file_id: The ID of the file to get
@@ -35,7 +42,7 @@ class Files(Base):
         """
         return self.client.get(f"/api/v4/files/{file_id}/thumbnail")
 
-    def get_file_preview(self, file_id):
+    def get_file_preview(self, file_id: str):
         """Get a file's preview
 
         file_id: The ID of the file to get
@@ -45,7 +52,7 @@ class Files(Base):
         """
         return self.client.get(f"/api/v4/files/{file_id}/preview")
 
-    def get_file_link(self, file_id):
+    def get_file_link(self, file_id: str):
         """Get a public file link
 
         file_id: The ID of the file to get a link for
@@ -55,7 +62,7 @@ class Files(Base):
         """
         return self.client.get(f"/api/v4/files/{file_id}/link")
 
-    def get_file_info(self, file_id):
+    def get_file_info(self, file_id: str):
         """Get metadata for a file
 
         file_id: The ID of the file info to get
@@ -65,7 +72,7 @@ class Files(Base):
         """
         return self.client.get(f"/api/v4/files/{file_id}/info")
 
-    def get_file_public(self, file_id, params=None):
+    def get_file_public(self, file_id: str, h: str):
         """Get a public file
 
         file_id: The ID of the file to get
@@ -74,9 +81,19 @@ class Files(Base):
         `Read in Mattermost API docs (files - GetFilePublic) <https://api.mattermost.com/#tag/files/operation/GetFilePublic>`_
 
         """
-        return self.client.get(f"/files/{file_id}/public", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"h": h}
+        return self.client.get(f"/files/{file_id}/public", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def search_files(self, team_id, data):
+    def search_files(
+        self,
+        team_id: str,
+        terms: str,
+        is_or_search: bool,
+        time_zone_offset: int | None = 0,
+        include_deleted_channels: bool | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Search files in a team
 
         team_id: Team GUID
@@ -90,9 +107,25 @@ class Files(Base):
         `Read in Mattermost API docs (files - SearchFiles) <https://api.mattermost.com/#tag/files/operation/SearchFiles>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/files/search", data=data)
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "terms": terms,
+            "is_or_search": is_or_search,
+            "time_zone_offset": time_zone_offset,
+            "include_deleted_channels": include_deleted_channels,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.post(f"/api/v4/teams/{team_id}/files/search", data=data_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def search_files(self, data):
+    def search_files(
+        self,
+        terms: str,
+        is_or_search: bool,
+        time_zone_offset: int | None = 0,
+        include_deleted_channels: bool | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Search files across the teams of the current user
 
         terms: The search terms as entered by the user. To search for files from a user include ``from:someusername``, using a user's username. To search in a specific channel include ``in:somechannel``, using the channel name (not the display name). To search for specific extensions include ``ext:extension``.
@@ -105,4 +138,12 @@ class Files(Base):
         `Read in Mattermost API docs (files - SearchFiles) <https://api.mattermost.com/#tag/files/operation/SearchFiles>`_
 
         """
-        return self.client.post("""/api/v4/files/search""", data=data)
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "terms": terms,
+            "is_or_search": is_or_search,
+            "time_zone_offset": time_zone_offset,
+            "include_deleted_channels": include_deleted_channels,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.post("""/api/v4/files/search""", data=data_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/files.py
+++ b/src/mattermostautodriver/endpoints/files.py
@@ -1,10 +1,10 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Files(Base):
 
-    def upload_file(self, files: str | None = None, channel_id: str | None = None, client_ids: str | None = None):
+    def upload_file(self, files: BinaryIO | None = None, channel_id: str | None = None, client_ids: str | None = None):
         """Upload a file
 
         files: A file to be uploaded

--- a/src/mattermostautodriver/endpoints/filtering.py
+++ b/src/mattermostautodriver/endpoints/filtering.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Filtering(Base):

--- a/src/mattermostautodriver/endpoints/filtering.py
+++ b/src/mattermostautodriver/endpoints/filtering.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Filtering(Base):
@@ -10,7 +11,7 @@ class Filtering(Base):
         """
         return self.client.get("""/api/v4/ip_filtering""")
 
-    def apply_ip_filters(self, options):
+    def apply_ip_filters(self, options: list[Any]):
         """Get all IP filters
         `Read in Mattermost API docs (filtering - ApplyIPFilters) <https://api.mattermost.com/#tag/filtering/operation/ApplyIPFilters>`_
 

--- a/src/mattermostautodriver/endpoints/groups.py
+++ b/src/mattermostautodriver/endpoints/groups.py
@@ -260,6 +260,15 @@ class Groups(Base):
         page: The page to select.
         per_page: The number of groups per page.
         filter_allow_reference: Boolean which filters in the group entries with the ``allow_reference`` attribute set.
+        include_member_count: Boolean which adds a ``member_count`` field to each group object.
+        include_timezones: Boolean which adds timezone information for group members.
+        include_total_count: Boolean which adds total count of groups in the response.
+        include_archived: Boolean which includes archived groups in the response.
+        filter_archived: Boolean which filters out archived groups from the response.
+        filter_parent_team_permitted: Boolean which filters groups based on parent team permissions.
+        filter_has_member: User ID to filter groups that have this member.
+        include_member_ids: Boolean which adds member IDs to the group objects.
+        only_syncable_sources: Boolean which includes groups from syncable sources.
 
         `Read in Mattermost API docs (groups - GetGroupsByTeam) <https://api.mattermost.com/#tag/groups/operation/GetGroupsByTeam>`_
 

--- a/src/mattermostautodriver/endpoints/groups.py
+++ b/src/mattermostautodriver/endpoints/groups.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Groups(Base):

--- a/src/mattermostautodriver/endpoints/groups.py
+++ b/src/mattermostautodriver/endpoints/groups.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Groups(Base):
 
-    def unlink_ldap_group(self, remote_id):
+    def unlink_ldap_group(self, remote_id: str):
         """Delete a link for LDAP group
 
         remote_id: Group GUID
@@ -13,7 +14,17 @@ class Groups(Base):
         """
         return self.client.delete(f"/api/v4/ldap/groups/{remote_id}/link")
 
-    def get_groups(self, params=None):
+    def get_groups(
+        self,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        q: str | None = None,
+        include_member_count: bool | None = None,
+        not_associated_to_team: str | None = None,
+        not_associated_to_channel: str | None = None,
+        since: int | None = None,
+        filter_allow_reference: bool | None = False,
+    ):
         """Get groups
 
         page: The page to select.
@@ -30,9 +41,19 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - GetGroups) <https://api.mattermost.com/#tag/groups/operation/GetGroups>`_
 
         """
-        return self.client.get("""/api/v4/groups""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "q": q,
+            "include_member_count": include_member_count,
+            "not_associated_to_team": not_associated_to_team,
+            "not_associated_to_channel": not_associated_to_channel,
+            "since": since,
+            "filter_allow_reference": filter_allow_reference,
+        }
+        return self.client.get("""/api/v4/groups""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_group(self, options):
+    def create_group(self, group: dict[str, Any], user_ids: list[str]):
         """Create a custom group
 
         group: Group object to create.
@@ -41,9 +62,10 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - CreateGroup) <https://api.mattermost.com/#tag/groups/operation/CreateGroup>`_
 
         """
-        return self.client.post("""/api/v4/groups""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"group": group, "user_ids": user_ids}
+        return self.client.post("""/api/v4/groups""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_group(self, group_id):
+    def get_group(self, group_id: str):
         """Get a group
 
         group_id: Group GUID
@@ -53,7 +75,7 @@ class Groups(Base):
         """
         return self.client.get(f"/api/v4/groups/{group_id}")
 
-    def delete_group(self, group_id):
+    def delete_group(self, group_id: str):
         """Deletes a custom group
 
         group_id: The ID of the group.
@@ -63,7 +85,9 @@ class Groups(Base):
         """
         return self.client.delete(f"/api/v4/groups/{group_id}")
 
-    def patch_group(self, group_id, options):
+    def patch_group(
+        self, group_id: str, name: str | None = None, display_name: str | None = None, description: str | None = None
+    ):
         """Patch a group
 
         group_id: Group GUID
@@ -74,9 +98,14 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - PatchGroup) <https://api.mattermost.com/#tag/groups/operation/PatchGroup>`_
 
         """
-        return self.client.put(f"/api/v4/groups/{group_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "name": name,
+            "display_name": display_name,
+            "description": description,
+        }
+        return self.client.put(f"/api/v4/groups/{group_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def restore_group(self, group_id):
+    def restore_group(self, group_id: str):
         """Restore a previously deleted group.
 
         group_id: Group GUID
@@ -86,7 +115,7 @@ class Groups(Base):
         """
         return self.client.post(f"/api/v4/groups/{group_id}/restore")
 
-    def link_group_syncable_for_team(self, group_id, team_id):
+    def link_group_syncable_for_team(self, group_id: str, team_id: str):
         """Link a team to a group
 
         group_id: Group GUID
@@ -97,7 +126,7 @@ class Groups(Base):
         """
         return self.client.post(f"/api/v4/groups/{group_id}/teams/{team_id}/link")
 
-    def unlink_group_syncable_for_team(self, group_id, team_id):
+    def unlink_group_syncable_for_team(self, group_id: str, team_id: str):
         """Delete a link from a team to a group
 
         group_id: Group GUID
@@ -108,7 +137,7 @@ class Groups(Base):
         """
         return self.client.delete(f"/api/v4/groups/{group_id}/teams/{team_id}/link")
 
-    def link_group_syncable_for_channel(self, group_id, channel_id):
+    def link_group_syncable_for_channel(self, group_id: str, channel_id: str):
         """Link a channel to a group
 
         group_id: Group GUID
@@ -119,7 +148,7 @@ class Groups(Base):
         """
         return self.client.post(f"/api/v4/groups/{group_id}/channels/{channel_id}/link")
 
-    def unlink_group_syncable_for_channel(self, group_id, channel_id):
+    def unlink_group_syncable_for_channel(self, group_id: str, channel_id: str):
         """Delete a link from a channel to a group
 
         group_id: Group GUID
@@ -130,7 +159,7 @@ class Groups(Base):
         """
         return self.client.delete(f"/api/v4/groups/{group_id}/channels/{channel_id}/link")
 
-    def get_group_syncable_for_team_id(self, group_id, team_id):
+    def get_group_syncable_for_team_id(self, group_id: str, team_id: str):
         """Get GroupSyncable from Team ID
 
         group_id: Group GUID
@@ -141,7 +170,7 @@ class Groups(Base):
         """
         return self.client.get(f"/api/v4/groups/{group_id}/teams/{team_id}")
 
-    def get_group_syncable_for_channel_id(self, group_id, channel_id):
+    def get_group_syncable_for_channel_id(self, group_id: str, channel_id: str):
         """Get GroupSyncable from channel ID
 
         group_id: Group GUID
@@ -152,7 +181,7 @@ class Groups(Base):
         """
         return self.client.get(f"/api/v4/groups/{group_id}/channels/{channel_id}")
 
-    def get_group_syncables_teams(self, group_id):
+    def get_group_syncables_teams(self, group_id: str):
         """Get group teams
 
         group_id: Group GUID
@@ -162,7 +191,7 @@ class Groups(Base):
         """
         return self.client.get(f"/api/v4/groups/{group_id}/teams")
 
-    def get_group_syncables_channels(self, group_id):
+    def get_group_syncables_channels(self, group_id: str):
         """Get group channels
 
         group_id: Group GUID
@@ -172,7 +201,7 @@ class Groups(Base):
         """
         return self.client.get(f"/api/v4/groups/{group_id}/channels")
 
-    def patch_group_syncable_for_team(self, group_id, team_id, options):
+    def patch_group_syncable_for_team(self, group_id: str, team_id: str, auto_add: bool | None = None):
         """Patch a GroupSyncable associated to Team
 
         group_id: Group GUID
@@ -182,9 +211,12 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - PatchGroupSyncableForTeam) <https://api.mattermost.com/#tag/groups/operation/PatchGroupSyncableForTeam>`_
 
         """
-        return self.client.put(f"/api/v4/groups/{group_id}/teams/{team_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"auto_add": auto_add}
+        return self.client.put(
+            f"/api/v4/groups/{group_id}/teams/{team_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def patch_group_syncable_for_channel(self, group_id, channel_id, options):
+    def patch_group_syncable_for_channel(self, group_id: str, channel_id: str, auto_add: bool | None = None):
         """Patch a GroupSyncable associated to Channel
 
         group_id: Group GUID
@@ -194,9 +226,12 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - PatchGroupSyncableForChannel) <https://api.mattermost.com/#tag/groups/operation/PatchGroupSyncableForChannel>`_
 
         """
-        return self.client.put(f"/api/v4/groups/{group_id}/channels/{channel_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"auto_add": auto_add}
+        return self.client.put(
+            f"/api/v4/groups/{group_id}/channels/{channel_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_group_users(self, group_id, params=None):
+    def get_group_users(self, group_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get group users
 
         group_id: Group GUID
@@ -206,9 +241,10 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - GetGroupUsers) <https://api.mattermost.com/#tag/groups/operation/GetGroupUsers>`_
 
         """
-        return self.client.get(f"/api/v4/groups/{group_id}/members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/groups/{group_id}/members", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def delete_group_members(self, group_id, params):
+    def delete_group_members(self, group_id: str, user_ids: list[str] | None = None):
         """Removes members from a custom group
 
         group_id: The ID of the group to delete.
@@ -217,9 +253,10 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - DeleteGroupMembers) <https://api.mattermost.com/#tag/groups/operation/DeleteGroupMembers>`_
 
         """
-        return self.client.delete(f"/api/v4/groups/{group_id}/members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"user_ids": user_ids}
+        return self.client.delete(f"/api/v4/groups/{group_id}/members", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def add_group_members(self, group_id, options):
+    def add_group_members(self, group_id: str, user_ids: list[str] | None = None):
         """Adds members to a custom group
 
         group_id: The ID of the group.
@@ -228,9 +265,10 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - AddGroupMembers) <https://api.mattermost.com/#tag/groups/operation/AddGroupMembers>`_
 
         """
-        return self.client.post(f"/api/v4/groups/{group_id}/members", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"user_ids": user_ids}
+        return self.client.post(f"/api/v4/groups/{group_id}/members", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_group_stats(self, group_id):
+    def get_group_stats(self, group_id: str):
         """Get group stats
 
         group_id: Group GUID
@@ -240,7 +278,13 @@ class Groups(Base):
         """
         return self.client.get(f"/api/v4/groups/{group_id}/stats")
 
-    def get_groups_by_channel(self, channel_id, params=None):
+    def get_groups_by_channel(
+        self,
+        channel_id: str,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        filter_allow_reference: bool | None = False,
+    ):
         """Get channel groups
 
         channel_id: Channel GUID
@@ -251,9 +295,29 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - GetGroupsByChannel) <https://api.mattermost.com/#tag/groups/operation/GetGroupsByChannel>`_
 
         """
-        return self.client.get(f"/api/v4/channels/{channel_id}/groups", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "filter_allow_reference": filter_allow_reference,
+        }
+        return self.client.get(f"/api/v4/channels/{channel_id}/groups", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_groups_by_team(self, team_id, params=None):
+    def get_groups_by_team(
+        self,
+        team_id: str,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        filter_allow_reference: bool | None = False,
+        include_member_count: bool | None = False,
+        include_timezones: bool | None = False,
+        include_total_count: bool | None = False,
+        include_archived: bool | None = False,
+        filter_archived: bool | None = False,
+        filter_parent_team_permitted: bool | None = False,
+        filter_has_member: str | None = None,
+        include_member_ids: bool | None = False,
+        only_syncable_sources: bool | None = False,
+    ):
         """Get team groups
 
         team_id: Team GUID
@@ -273,9 +337,30 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - GetGroupsByTeam) <https://api.mattermost.com/#tag/groups/operation/GetGroupsByTeam>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/groups", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "filter_allow_reference": filter_allow_reference,
+            "include_member_count": include_member_count,
+            "include_timezones": include_timezones,
+            "include_total_count": include_total_count,
+            "include_archived": include_archived,
+            "filter_archived": filter_archived,
+            "filter_parent_team_permitted": filter_parent_team_permitted,
+            "filter_has_member": filter_has_member,
+            "include_member_ids": include_member_ids,
+            "only_syncable_sources": only_syncable_sources,
+        }
+        return self.client.get(f"/api/v4/teams/{team_id}/groups", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_groups_associated_to_channels_by_team(self, team_id, params=None):
+    def get_groups_associated_to_channels_by_team(
+        self,
+        team_id: str,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        filter_allow_reference: bool | None = False,
+        paginate: bool | None = False,
+    ):
         """Get team groups by channels
 
         team_id: Team GUID
@@ -287,9 +372,17 @@ class Groups(Base):
         `Read in Mattermost API docs (groups - GetGroupsAssociatedToChannelsByTeam) <https://api.mattermost.com/#tag/groups/operation/GetGroupsAssociatedToChannelsByTeam>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/groups_by_channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "filter_allow_reference": filter_allow_reference,
+            "paginate": paginate,
+        }
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/groups_by_channels", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_groups_by_user_id(self, user_id):
+    def get_groups_by_user_id(self, user_id: str):
         """Get groups for a userId
 
         user_id: User GUID

--- a/src/mattermostautodriver/endpoints/imports.py
+++ b/src/mattermostautodriver/endpoints/imports.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Imports(Base):

--- a/src/mattermostautodriver/endpoints/imports.py
+++ b/src/mattermostautodriver/endpoints/imports.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Imports(Base):

--- a/src/mattermostautodriver/endpoints/integration_actions.py
+++ b/src/mattermostautodriver/endpoints/integration_actions.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class IntegrationActions(Base):

--- a/src/mattermostautodriver/endpoints/integration_actions.py
+++ b/src/mattermostautodriver/endpoints/integration_actions.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class IntegrationActions(Base):
 
-    def open_interactive_dialog(self, options):
+    def open_interactive_dialog(self, trigger_id: str, url: str, dialog: dict[str, Any]):
         """Open a dialog
 
         trigger_id: Trigger ID provided by other action
@@ -13,9 +14,19 @@ class IntegrationActions(Base):
         `Read in Mattermost API docs (integration_actions - OpenInteractiveDialog) <https://api.mattermost.com/#tag/integration_actions/operation/OpenInteractiveDialog>`_
 
         """
-        return self.client.post("""/api/v4/actions/dialogs/open""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"trigger_id": trigger_id, "url": url, "dialog": dialog}
+        return self.client.post("""/api/v4/actions/dialogs/open""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def submit_interactive_dialog(self, options):
+    def submit_interactive_dialog(
+        self,
+        url: str,
+        channel_id: str,
+        team_id: str,
+        submission: dict[str, Any],
+        callback_id: str | None = None,
+        state: str | None = None,
+        cancelled: bool | None = None,
+    ):
         """Submit a dialog
 
         url: The URL to send the submitted dialog payload to
@@ -29,4 +40,13 @@ class IntegrationActions(Base):
         `Read in Mattermost API docs (integration_actions - SubmitInteractiveDialog) <https://api.mattermost.com/#tag/integration_actions/operation/SubmitInteractiveDialog>`_
 
         """
-        return self.client.post("""/api/v4/actions/dialogs/submit""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "url": url,
+            "channel_id": channel_id,
+            "team_id": team_id,
+            "submission": submission,
+            "callback_id": callback_id,
+            "state": state,
+            "cancelled": cancelled,
+        }
+        return self.client.post("""/api/v4/actions/dialogs/submit""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/internal.py
+++ b/src/mattermostautodriver/endpoints/internal.py
@@ -1,9 +1,21 @@
 from .base import Base
+from typing import Any
 
 
 class Internal(Base):
 
-    def create_playbook_run_from_dialog(self, options=None):
+    def create_playbook_run_from_dialog(
+        self,
+        type: str | None = None,
+        url: str | None = None,
+        callback_id: str | None = None,
+        state: str | None = None,
+        user_id: str | None = None,
+        channel_id: str | None = None,
+        team_id: str | None = None,
+        submission: dict[str, Any] | None = None,
+        cancelled: bool | None = None,
+    ):
         """Create a new playbook run from dialog
 
         type:
@@ -19,9 +31,22 @@ class Internal(Base):
         `Read in Mattermost API docs (Internal - createPlaybookRunFromDialog) <https://api.mattermost.com/#tag/Internal/operation/createPlaybookRunFromDialog>`_
 
         """
-        return self.client.post("""/plugins/playbooks/api/v0/runs/dialog""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "type": type,
+            "url": url,
+            "callback_id": callback_id,
+            "state": state,
+            "user_id": user_id,
+            "channel_id": channel_id,
+            "team_id": team_id,
+            "submission": submission,
+            "cancelled": cancelled,
+        }
+        return self.client.post(
+            """/plugins/playbooks/api/v0/runs/dialog""", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_checklist_autocomplete(self, params=None):
+    def get_checklist_autocomplete(self, channel_ID: str):
         """Get autocomplete data for /playbook check
 
         channel_ID: ID of the channel the user is in.
@@ -29,9 +54,12 @@ class Internal(Base):
         `Read in Mattermost API docs (Internal - getChecklistAutocomplete) <https://api.mattermost.com/#tag/Internal/operation/getChecklistAutocomplete>`_
 
         """
-        return self.client.get("""/plugins/playbooks/api/v0/runs/checklist-autocomplete""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_ID": channel_ID}
+        return self.client.get(
+            """/plugins/playbooks/api/v0/runs/checklist-autocomplete""", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def end_playbook_run_dialog(self, id):
+    def end_playbook_run_dialog(self, id: str):
         """End a playbook run from dialog
 
         id: ID of the playbook run to end.
@@ -41,7 +69,7 @@ class Internal(Base):
         """
         return self.client.post(f"/plugins/playbooks/api/v0/runs/{id}/end")
 
-    def next_stage_dialog(self, id, options=None):
+    def next_stage_dialog(self, id: str, state: str | None = None):
         """Go to next stage from dialog
 
         id: The PlaybookRun ID
@@ -50,4 +78,7 @@ class Internal(Base):
         `Read in Mattermost API docs (Internal - nextStageDialog) <https://api.mattermost.com/#tag/Internal/operation/nextStageDialog>`_
 
         """
-        return self.client.post(f"/plugins/playbooks/api/v0/runs/{id}/next-stage-dialog", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"state": state}
+        return self.client.post(
+            f"/plugins/playbooks/api/v0/runs/{id}/next-stage-dialog", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )

--- a/src/mattermostautodriver/endpoints/internal.py
+++ b/src/mattermostautodriver/endpoints/internal.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Internal(Base):

--- a/src/mattermostautodriver/endpoints/ip.py
+++ b/src/mattermostautodriver/endpoints/ip.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Ip(Base):

--- a/src/mattermostautodriver/endpoints/ip.py
+++ b/src/mattermostautodriver/endpoints/ip.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Ip(Base):
@@ -10,7 +11,7 @@ class Ip(Base):
         """
         return self.client.get("""/api/v4/ip_filtering""")
 
-    def apply_ip_filters(self, options):
+    def apply_ip_filters(self, options: list[Any]):
         """Get all IP filters
         `Read in Mattermost API docs (ip - ApplyIPFilters) <https://api.mattermost.com/#tag/ip/operation/ApplyIPFilters>`_
 

--- a/src/mattermostautodriver/endpoints/jobs.py
+++ b/src/mattermostautodriver/endpoints/jobs.py
@@ -1,9 +1,12 @@
 from .base import Base
+from typing import Any
 
 
 class Jobs(Base):
 
-    def get_jobs(self, params=None):
+    def get_jobs(
+        self, page: int | None = 0, per_page: int | None = 5, job_type: str | None = None, status: str | None = None
+    ):
         """Get the jobs.
 
         page: The page to select.
@@ -14,9 +17,15 @@ class Jobs(Base):
         `Read in Mattermost API docs (jobs - GetJobs) <https://api.mattermost.com/#tag/jobs/operation/GetJobs>`_
 
         """
-        return self.client.get("""/api/v4/jobs""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "job_type": job_type,
+            "status": status,
+        }
+        return self.client.get("""/api/v4/jobs""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_job(self, options):
+    def create_job(self, type: str, data: dict[str, Any] | None = None):
         """Create a new job.
 
         type: The type of job to create
@@ -25,9 +34,10 @@ class Jobs(Base):
         `Read in Mattermost API docs (jobs - CreateJob) <https://api.mattermost.com/#tag/jobs/operation/CreateJob>`_
 
         """
-        return self.client.post("""/api/v4/jobs""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"type": type, "data": data}
+        return self.client.post("""/api/v4/jobs""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_job(self, job_id):
+    def get_job(self, job_id: str):
         """Get a job.
 
         job_id: Job GUID
@@ -37,7 +47,7 @@ class Jobs(Base):
         """
         return self.client.get(f"/api/v4/jobs/{job_id}")
 
-    def download_job(self, job_id):
+    def download_job(self, job_id: str):
         """Download the results of a job.
 
         job_id: Job GUID
@@ -47,7 +57,7 @@ class Jobs(Base):
         """
         return self.client.get(f"/api/v4/jobs/{job_id}/download")
 
-    def cancel_job(self, job_id):
+    def cancel_job(self, job_id: str):
         """Cancel a job.
 
         job_id: Job GUID
@@ -57,7 +67,7 @@ class Jobs(Base):
         """
         return self.client.post(f"/api/v4/jobs/{job_id}/cancel")
 
-    def get_jobs_by_type(self, type, params=None):
+    def get_jobs_by_type(self, type: str, page: int | None = 0, per_page: int | None = 60):
         """Get the jobs of the given type.
 
         type: Job type
@@ -67,9 +77,10 @@ class Jobs(Base):
         `Read in Mattermost API docs (jobs - GetJobsByType) <https://api.mattermost.com/#tag/jobs/operation/GetJobsByType>`_
 
         """
-        return self.client.get(f"/api/v4/jobs/type/{type}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/jobs/type/{type}", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_job_status(self, job_id, options):
+    def update_job_status(self, job_id: str, status: str, force: bool | None = None):
         """Update the status of a job
 
         job_id: Job GUID
@@ -79,4 +90,5 @@ class Jobs(Base):
         `Read in Mattermost API docs (jobs - UpdateJobStatus) <https://api.mattermost.com/#tag/jobs/operation/UpdateJobStatus>`_
 
         """
-        return self.client.patch(f"/api/v4/jobs/{job_id}/status", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"status": status, "force": force}
+        return self.client.patch(f"/api/v4/jobs/{job_id}/status", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/jobs.py
+++ b/src/mattermostautodriver/endpoints/jobs.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Jobs(Base):

--- a/src/mattermostautodriver/endpoints/ldap.py
+++ b/src/mattermostautodriver/endpoints/ldap.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Ldap(Base):

--- a/src/mattermostautodriver/endpoints/ldap.py
+++ b/src/mattermostautodriver/endpoints/ldap.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Ldap(Base):
 
-    def get_ldap_groups(self, params=None):
+    def get_ldap_groups(self, q: str | None = None, page: int | None = 0, per_page: int | None = 60):
         """Returns a list of LDAP groups
 
         q: Search term
@@ -13,9 +14,10 @@ class Ldap(Base):
         `Read in Mattermost API docs (ldap - GetLdapGroups) <https://api.mattermost.com/#tag/ldap/operation/GetLdapGroups>`_
 
         """
-        return self.client.get("""/api/v4/ldap/groups""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"q": q, "page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/ldap/groups""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def link_ldap_group(self, remote_id):
+    def link_ldap_group(self, remote_id: str):
         """Link a LDAP group
 
         remote_id: Group GUID

--- a/src/mattermostautodriver/endpoints/logs.py
+++ b/src/mattermostautodriver/endpoints/logs.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Logs(Base):

--- a/src/mattermostautodriver/endpoints/logs.py
+++ b/src/mattermostautodriver/endpoints/logs.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Logs(Base):

--- a/src/mattermostautodriver/endpoints/metrics.py
+++ b/src/mattermostautodriver/endpoints/metrics.py
@@ -1,9 +1,19 @@
 from .base import Base
+from typing import Any
 
 
 class Metrics(Base):
 
-    def submit_performance_report(self, options=None):
+    def submit_performance_report(
+        self,
+        version: str,
+        start: int,
+        end: int,
+        client_id: str | None = None,
+        labels: list[str] | None = None,
+        counters: list[dict[str, Any]] | None = None,
+        histograms: list[dict[str, Any]] | None = None,
+    ):
         """Report client performance metrics
 
         version: An identifier for the schema of the data being submitted which currently must be "0.1.0"
@@ -17,4 +27,13 @@ class Metrics(Base):
         `Read in Mattermost API docs (metrics - SubmitPerformanceReport) <https://api.mattermost.com/#tag/metrics/operation/SubmitPerformanceReport>`_
 
         """
-        return self.client.post("""/api/v4/client_perf""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "version": version,
+            "client_id": client_id,
+            "labels": labels,
+            "start": start,
+            "end": end,
+            "counters": counters,
+            "histograms": histograms,
+        }
+        return self.client.post("""/api/v4/client_perf""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/metrics.py
+++ b/src/mattermostautodriver/endpoints/metrics.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Metrics(Base):

--- a/src/mattermostautodriver/endpoints/migrate.py
+++ b/src/mattermostautodriver/endpoints/migrate.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Migrate(Base):

--- a/src/mattermostautodriver/endpoints/migrate.py
+++ b/src/mattermostautodriver/endpoints/migrate.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Migrate(Base):
 
-    def migrate_auth_to_ldap(self, options=None):
+    def migrate_auth_to_ldap(self, from_: str, match_field: str, force: bool):
         """Migrate user accounts authentication type to LDAP.
 
         from: The current authentication type for the matched users.
@@ -13,9 +14,10 @@ class Migrate(Base):
         `Read in Mattermost API docs (migrate - MigrateAuthToLdap) <https://api.mattermost.com/#tag/migrate/operation/MigrateAuthToLdap>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/ldap""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "match_field": match_field, "force": force}
+        return self.client.post("""/api/v4/users/migrate_auth/ldap""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def migrate_auth_to_saml(self, options=None):
+    def migrate_auth_to_saml(self, from_: str, matches: dict[str, Any], auto: bool):
         """Migrate user accounts authentication type to SAML.
 
         from: The current authentication type for the matched users.
@@ -25,4 +27,5 @@ class Migrate(Base):
         `Read in Mattermost API docs (migrate - MigrateAuthToSaml) <https://api.mattermost.com/#tag/migrate/operation/MigrateAuthToSaml>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "matches": matches, "auto": auto}
+        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/oauth.py
+++ b/src/mattermostautodriver/endpoints/oauth.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Oauth(Base):

--- a/src/mattermostautodriver/endpoints/oauth.py
+++ b/src/mattermostautodriver/endpoints/oauth.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Oauth(Base):
 
-    def list_outgoing_o_auth_connections(self, params=None):
+    def list_outgoing_o_auth_connections(self, team_id: str):
         """List all connections
 
         team_id: Current Team ID in integrations backstage
@@ -11,16 +12,17 @@ class Oauth(Base):
         `Read in Mattermost API docs (oauth - ListOutgoingOAuthConnections) <https://api.mattermost.com/#tag/oauth/operation/ListOutgoingOAuthConnections>`_
 
         """
-        return self.client.get("""/api/v4/oauth/outgoing_connections""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get("""/api/v4/oauth/outgoing_connections""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_outgoing_o_auth_connection(self, options=None):
+    def create_outgoing_o_auth_connection(self, options: Any | None = None):
         """Create a connection
         `Read in Mattermost API docs (oauth - CreateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/oauth/operation/CreateOutgoingOAuthConnection>`_
 
         """
         return self.client.post("""/api/v4/oauth/outgoing_connections""", options=options)
 
-    def get_outgoing_o_auth_connection(self, params=None):
+    def get_outgoing_o_auth_connection(self, team_id: str):
         """Get a connection
 
         team_id: Current Team ID in integrations backstage
@@ -28,9 +30,12 @@ class Oauth(Base):
         `Read in Mattermost API docs (oauth - GetOutgoingOAuthConnection) <https://api.mattermost.com/#tag/oauth/operation/GetOutgoingOAuthConnection>`_
 
         """
-        return self.client.get(f"/api/v4/oauth/outgoing_connections/{connection_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get(
+            f"/api/v4/oauth/outgoing_connections/{connection_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_outgoing_o_auth_connection(self, options=None):
+    def update_outgoing_o_auth_connection(self, options: Any | None = None):
         """Update a connection
         `Read in Mattermost API docs (oauth - UpdateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/oauth/operation/UpdateOutgoingOAuthConnection>`_
 
@@ -44,7 +49,7 @@ class Oauth(Base):
         """
         return self.client.delete(f"/api/v4/oauth/outgoing_connections/{connection_id}")
 
-    def validate_outgoing_o_auth_connection(self, options=None):
+    def validate_outgoing_o_auth_connection(self, options: Any | None = None):
         """Validate a connection configuration
         `Read in Mattermost API docs (oauth - ValidateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/oauth/operation/ValidateOutgoingOAuthConnection>`_
 

--- a/src/mattermostautodriver/endpoints/outgoing_connections.py
+++ b/src/mattermostautodriver/endpoints/outgoing_connections.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class OutgoingConnections(Base):
 
-    def list_outgoing_o_auth_connections(self, params=None):
+    def list_outgoing_o_auth_connections(self, team_id: str):
         """List all connections
 
         team_id: Current Team ID in integrations backstage
@@ -11,16 +12,17 @@ class OutgoingConnections(Base):
         `Read in Mattermost API docs (outgoing_connections - ListOutgoingOAuthConnections) <https://api.mattermost.com/#tag/outgoing_connections/operation/ListOutgoingOAuthConnections>`_
 
         """
-        return self.client.get("""/api/v4/oauth/outgoing_connections""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get("""/api/v4/oauth/outgoing_connections""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_outgoing_o_auth_connection(self, options=None):
+    def create_outgoing_o_auth_connection(self, options: Any | None = None):
         """Create a connection
         `Read in Mattermost API docs (outgoing_connections - CreateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_connections/operation/CreateOutgoingOAuthConnection>`_
 
         """
         return self.client.post("""/api/v4/oauth/outgoing_connections""", options=options)
 
-    def get_outgoing_o_auth_connection(self, params=None):
+    def get_outgoing_o_auth_connection(self, team_id: str):
         """Get a connection
 
         team_id: Current Team ID in integrations backstage
@@ -28,9 +30,12 @@ class OutgoingConnections(Base):
         `Read in Mattermost API docs (outgoing_connections - GetOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_connections/operation/GetOutgoingOAuthConnection>`_
 
         """
-        return self.client.get(f"/api/v4/oauth/outgoing_connections/{connection_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get(
+            f"/api/v4/oauth/outgoing_connections/{connection_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_outgoing_o_auth_connection(self, options=None):
+    def update_outgoing_o_auth_connection(self, options: Any | None = None):
         """Update a connection
         `Read in Mattermost API docs (outgoing_connections - UpdateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_connections/operation/UpdateOutgoingOAuthConnection>`_
 
@@ -44,7 +49,7 @@ class OutgoingConnections(Base):
         """
         return self.client.delete(f"/api/v4/oauth/outgoing_connections/{connection_id}")
 
-    def validate_outgoing_o_auth_connection(self, options=None):
+    def validate_outgoing_o_auth_connection(self, options: Any | None = None):
         """Validate a connection configuration
         `Read in Mattermost API docs (outgoing_connections - ValidateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_connections/operation/ValidateOutgoingOAuthConnection>`_
 

--- a/src/mattermostautodriver/endpoints/outgoing_connections.py
+++ b/src/mattermostautodriver/endpoints/outgoing_connections.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class OutgoingConnections(Base):

--- a/src/mattermostautodriver/endpoints/outgoing_oauth_connections.py
+++ b/src/mattermostautodriver/endpoints/outgoing_oauth_connections.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class OutgoingOauthConnections(Base):

--- a/src/mattermostautodriver/endpoints/outgoing_oauth_connections.py
+++ b/src/mattermostautodriver/endpoints/outgoing_oauth_connections.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class OutgoingOauthConnections(Base):
 
-    def list_outgoing_o_auth_connections(self, params=None):
+    def list_outgoing_o_auth_connections(self, team_id: str):
         """List all connections
 
         team_id: Current Team ID in integrations backstage
@@ -11,16 +12,17 @@ class OutgoingOauthConnections(Base):
         `Read in Mattermost API docs (outgoing_oauth_connections - ListOutgoingOAuthConnections) <https://api.mattermost.com/#tag/outgoing_oauth_connections/operation/ListOutgoingOAuthConnections>`_
 
         """
-        return self.client.get("""/api/v4/oauth/outgoing_connections""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get("""/api/v4/oauth/outgoing_connections""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_outgoing_o_auth_connection(self, options=None):
+    def create_outgoing_o_auth_connection(self, options: Any | None = None):
         """Create a connection
         `Read in Mattermost API docs (outgoing_oauth_connections - CreateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_oauth_connections/operation/CreateOutgoingOAuthConnection>`_
 
         """
         return self.client.post("""/api/v4/oauth/outgoing_connections""", options=options)
 
-    def get_outgoing_o_auth_connection(self, params=None):
+    def get_outgoing_o_auth_connection(self, team_id: str):
         """Get a connection
 
         team_id: Current Team ID in integrations backstage
@@ -28,9 +30,12 @@ class OutgoingOauthConnections(Base):
         `Read in Mattermost API docs (outgoing_oauth_connections - GetOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_oauth_connections/operation/GetOutgoingOAuthConnection>`_
 
         """
-        return self.client.get(f"/api/v4/oauth/outgoing_connections/{connection_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get(
+            f"/api/v4/oauth/outgoing_connections/{connection_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_outgoing_o_auth_connection(self, options=None):
+    def update_outgoing_o_auth_connection(self, options: Any | None = None):
         """Update a connection
         `Read in Mattermost API docs (outgoing_oauth_connections - UpdateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_oauth_connections/operation/UpdateOutgoingOAuthConnection>`_
 
@@ -44,7 +49,7 @@ class OutgoingOauthConnections(Base):
         """
         return self.client.delete(f"/api/v4/oauth/outgoing_connections/{connection_id}")
 
-    def validate_outgoing_o_auth_connection(self, options=None):
+    def validate_outgoing_o_auth_connection(self, options: Any | None = None):
         """Validate a connection configuration
         `Read in Mattermost API docs (outgoing_oauth_connections - ValidateOutgoingOAuthConnection) <https://api.mattermost.com/#tag/outgoing_oauth_connections/operation/ValidateOutgoingOAuthConnection>`_
 

--- a/src/mattermostautodriver/endpoints/permissions.py
+++ b/src/mattermostautodriver/endpoints/permissions.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Permissions(Base):
 
-    def get_ancillary_permissions_post(self, options):
+    def get_ancillary_permissions_post(self, options: list[str]):
         """Return all system console subsection ancillary permissions
         `Read in Mattermost API docs (permissions - GetAncillaryPermissionsPost) <https://api.mattermost.com/#tag/permissions/operation/GetAncillaryPermissionsPost>`_
 

--- a/src/mattermostautodriver/endpoints/permissions.py
+++ b/src/mattermostautodriver/endpoints/permissions.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Permissions(Base):

--- a/src/mattermostautodriver/endpoints/playbookautofollows.py
+++ b/src/mattermostautodriver/endpoints/playbookautofollows.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class PlaybookAutofollows(Base):
 
-    def get_auto_follows(self, id):
+    def get_auto_follows(self, id: str):
         """Get the list of followers' user IDs of a playbook
 
         id: ID of the playbook to retrieve followers from.

--- a/src/mattermostautodriver/endpoints/playbookautofollows.py
+++ b/src/mattermostautodriver/endpoints/playbookautofollows.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class PlaybookAutofollows(Base):

--- a/src/mattermostautodriver/endpoints/playbookruns.py
+++ b/src/mattermostautodriver/endpoints/playbookruns.py
@@ -1,9 +1,21 @@
 from .base import Base
+from typing import Any
 
 
 class PlaybookRuns(Base):
 
-    def list_playbook_runs(self, params=None):
+    def list_playbook_runs(
+        self,
+        team_id: str,
+        page: int | None = 0,
+        per_page: int | None = 1000,
+        sort: str | None = "create_at",
+        direction: str | None = "desc",
+        statuses: list[str] | None = ["InProgress"],
+        owner_user_id: str | None = None,
+        participant_id: str | None = None,
+        search_term: str | None = None,
+    ):
         """List all playbook runs
 
         team_id: ID of the team to filter by.
@@ -19,9 +31,28 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - listPlaybookRuns) <https://api.mattermost.com/#tag/PlaybookRuns/operation/listPlaybookRuns>`_
 
         """
-        return self.client.get("""/plugins/playbooks/api/v0/runs""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "page": page,
+            "per_page": per_page,
+            "sort": sort,
+            "direction": direction,
+            "statuses": statuses,
+            "owner_user_id": owner_user_id,
+            "participant_id": participant_id,
+            "search_term": search_term,
+        }
+        return self.client.get("""/plugins/playbooks/api/v0/runs""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_playbook_run_from_post(self, options=None):
+    def create_playbook_run_from_post(
+        self,
+        name: str,
+        owner_user_id: str,
+        team_id: str,
+        playbook_id: str,
+        description: str | None = None,
+        post_id: str | None = None,
+    ):
         """Create a new playbook run
 
         name: The name of the playbook run.
@@ -34,9 +65,17 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - createPlaybookRunFromPost) <https://api.mattermost.com/#tag/PlaybookRuns/operation/createPlaybookRunFromPost>`_
 
         """
-        return self.client.post("""/plugins/playbooks/api/v0/runs""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "name": name,
+            "description": description,
+            "owner_user_id": owner_user_id,
+            "team_id": team_id,
+            "post_id": post_id,
+            "playbook_id": playbook_id,
+        }
+        return self.client.post("""/plugins/playbooks/api/v0/runs""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_owners(self, params=None):
+    def get_owners(self, team_id: str):
         """Get all owners
 
         team_id: ID of the team to filter by.
@@ -44,9 +83,21 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - getOwners) <https://api.mattermost.com/#tag/PlaybookRuns/operation/getOwners>`_
 
         """
-        return self.client.get("""/plugins/playbooks/api/v0/runs/owners""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id}
+        return self.client.get(
+            """/plugins/playbooks/api/v0/runs/owners""", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_channels(self, params=None):
+    def get_channels(
+        self,
+        team_id: str,
+        sort: str | None = "create_at",
+        direction: str | None = "desc",
+        status: str | None = "all",
+        owner_user_id: str | None = None,
+        search_term: str | None = None,
+        participant_id: str | None = None,
+    ):
         """Get playbook run channels
 
         team_id: ID of the team to filter by.
@@ -60,9 +111,20 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - getChannels) <https://api.mattermost.com/#tag/PlaybookRuns/operation/getChannels>`_
 
         """
-        return self.client.get("""/plugins/playbooks/api/v0/runs/channels""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "sort": sort,
+            "direction": direction,
+            "status": status,
+            "owner_user_id": owner_user_id,
+            "search_term": search_term,
+            "participant_id": participant_id,
+        }
+        return self.client.get(
+            """/plugins/playbooks/api/v0/runs/channels""", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_playbook_run_by_channel_id(self, channel_id):
+    def get_playbook_run_by_channel_id(self, channel_id: str):
         """Find playbook run by channel ID
 
         channel_id: ID of the channel associated to the playbook run to retrieve.
@@ -72,7 +134,7 @@ class PlaybookRuns(Base):
         """
         return self.client.get(f"/plugins/playbooks/api/v0/runs/channel/{channel_id}")
 
-    def get_playbook_run(self, id):
+    def get_playbook_run(self, id: str):
         """Get a playbook run
 
         id: ID of the playbook run to retrieve.
@@ -82,7 +144,7 @@ class PlaybookRuns(Base):
         """
         return self.client.get(f"/plugins/playbooks/api/v0/runs/{id}")
 
-    def update_playbook_run(self, id, options=None):
+    def update_playbook_run(self, id: str, active_stage: int | None = None):
         """Update a playbook run
 
         id: ID of the playbook run to retrieve.
@@ -91,9 +153,12 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - updatePlaybookRun) <https://api.mattermost.com/#tag/PlaybookRuns/operation/updatePlaybookRun>`_
 
         """
-        return self.client.patch(f"/plugins/playbooks/api/v0/runs/{id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"active_stage": active_stage}
+        return self.client.patch(
+            f"/plugins/playbooks/api/v0/runs/{id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_playbook_run_metadata(self, id):
+    def get_playbook_run_metadata(self, id: str):
         """Get playbook run metadata
 
         id: ID of the playbook run whose metadata will be retrieved.
@@ -103,7 +168,7 @@ class PlaybookRuns(Base):
         """
         return self.client.get(f"/plugins/playbooks/api/v0/runs/{id}/metadata")
 
-    def end_playbook_run(self, id):
+    def end_playbook_run(self, id: str):
         """End a playbook run
 
         id: ID of the playbook run to end.
@@ -113,7 +178,7 @@ class PlaybookRuns(Base):
         """
         return self.client.put(f"/plugins/playbooks/api/v0/runs/{id}/end")
 
-    def restart_playbook_run(self, id):
+    def restart_playbook_run(self, id: str):
         """Restart a playbook run
 
         id: ID of the playbook run to restart.
@@ -123,7 +188,7 @@ class PlaybookRuns(Base):
         """
         return self.client.put(f"/plugins/playbooks/api/v0/runs/{id}/restart")
 
-    def status(self, id, options=None):
+    def status(self, id: str, message: str, reminder: float | None = None):
         """Update a playbook run's status
 
         id: ID of the playbook run to update.
@@ -133,9 +198,12 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - status) <https://api.mattermost.com/#tag/PlaybookRuns/operation/status>`_
 
         """
-        return self.client.post(f"/plugins/playbooks/api/v0/runs/{id}/status", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"message": message, "reminder": reminder}
+        return self.client.post(
+            f"/plugins/playbooks/api/v0/runs/{id}/status", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def finish(self, id):
+    def finish(self, id: str):
         """Finish a playbook
 
         id: ID of the playbook run to finish.
@@ -145,7 +213,7 @@ class PlaybookRuns(Base):
         """
         return self.client.put(f"/plugins/playbooks/api/v0/runs/{id}/finish")
 
-    def change_owner(self, id, options=None):
+    def change_owner(self, id: str, owner_id: str):
         """Update playbook run owner
 
         id: ID of the playbook run whose owner will be changed.
@@ -154,9 +222,24 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - changeOwner) <https://api.mattermost.com/#tag/PlaybookRuns/operation/changeOwner>`_
 
         """
-        return self.client.post(f"/plugins/playbooks/api/v0/runs/{id}/owner", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"owner_id": owner_id}
+        return self.client.post(
+            f"/plugins/playbooks/api/v0/runs/{id}/owner", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def add_checklist_item(self, id, checklist, options=None):
+    def add_checklist_item(
+        self,
+        id: str,
+        checklist: int,
+        title: str,
+        state: str | None = None,
+        state_modified: int | None = None,
+        assignee_id: str | None = None,
+        assignee_modified: int | None = None,
+        command: str | None = None,
+        command_last_run: int | None = None,
+        description: str | None = None,
+    ):
         """Add an item to a playbook run's checklist
 
         id: ID of the playbook run whose checklist will be modified.
@@ -173,9 +256,22 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - addChecklistItem) <https://api.mattermost.com/#tag/PlaybookRuns/operation/addChecklistItem>`_
 
         """
-        return self.client.post(f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/add", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "title": title,
+            "state": state,
+            "state_modified": state_modified,
+            "assignee_id": assignee_id,
+            "assignee_modified": assignee_modified,
+            "command": command,
+            "command_last_run": command_last_run,
+            "description": description,
+        }
+        return self.client.post(
+            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/add",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def reoder_checklist_item(self, id, checklist, options=None):
+    def reoder_checklist_item(self, id: str, checklist: int, item_num: int, new_location: int):
         """Reorder an item in a playbook run's checklist
 
         id: ID of the playbook run whose checklist will be modified.
@@ -186,9 +282,13 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - reoderChecklistItem) <https://api.mattermost.com/#tag/PlaybookRuns/operation/reoderChecklistItem>`_
 
         """
-        return self.client.put(f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/reorder", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"item_num": item_num, "new_location": new_location}
+        return self.client.put(
+            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/reorder",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def item_rename(self, id, checklist, item, options=None):
+    def item_rename(self, id: str, checklist: int, item: int, title: str, command: str):
         """Update an item of a playbook run's checklist
 
         id: ID of the playbook run whose checklist will be modified.
@@ -200,11 +300,13 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - itemRename) <https://api.mattermost.com/#tag/PlaybookRuns/operation/itemRename>`_
 
         """
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"title": title, "command": command}
         return self.client.put(
-            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}", options=options
+            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
         )
 
-    def item_delete(self, id, checklist, item):
+    def item_delete(self, id: str, checklist: int, item: int):
         """Delete an item of a playbook run's checklist
 
         id: ID of the playbook run whose checklist will be modified.
@@ -216,7 +318,7 @@ class PlaybookRuns(Base):
         """
         return self.client.delete(f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}")
 
-    def item_set_state(self, id, checklist, item, options=None):
+    def item_set_state(self, id: str, checklist: int, item: int, new_state: str = ""):
         """Update the state of an item
 
         id: ID of the playbook run whose checklist will be modified.
@@ -227,11 +329,13 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - itemSetState) <https://api.mattermost.com/#tag/PlaybookRuns/operation/itemSetState>`_
 
         """
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"new_state": new_state}
         return self.client.put(
-            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}/state", options=options
+            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}/state",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
         )
 
-    def item_set_assignee(self, id, checklist, item, options=None):
+    def item_set_assignee(self, id: str, checklist: int, item: int, assignee_id: str):
         """Update the assignee of an item
 
         id: ID of the playbook run whose item will get a new assignee.
@@ -242,11 +346,13 @@ class PlaybookRuns(Base):
         `Read in Mattermost API docs (PlaybookRuns - itemSetAssignee) <https://api.mattermost.com/#tag/PlaybookRuns/operation/itemSetAssignee>`_
 
         """
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"assignee_id": assignee_id}
         return self.client.put(
-            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}/assignee", options=options
+            f"/plugins/playbooks/api/v0/runs/{id}/checklists/{checklist}/item/{item}/assignee",
+            options=options_71f8b7431cd64fcfa0dabd300d0636d2,
         )
 
-    def item_run(self, id, checklist, item):
+    def item_run(self, id: str, checklist: int, item: int):
         """Run an item's slash command
 
         id: ID of the playbook run whose item will be executed.

--- a/src/mattermostautodriver/endpoints/playbookruns.py
+++ b/src/mattermostautodriver/endpoints/playbookruns.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class PlaybookRuns(Base):

--- a/src/mattermostautodriver/endpoints/playbooks.py
+++ b/src/mattermostautodriver/endpoints/playbooks.py
@@ -1,9 +1,18 @@
 from .base import Base
+from typing import Any
 
 
 class Playbooks(Base):
 
-    def get_playbooks(self, params=None):
+    def get_playbooks(
+        self,
+        team_id: str,
+        page: int | None = 0,
+        per_page: int | None = 1000,
+        sort: str | None = "title",
+        direction: str | None = "asc",
+        with_archived: bool | None = False,
+    ):
         """List all playbooks
 
         team_id: ID of the team to filter by.
@@ -16,9 +25,39 @@ class Playbooks(Base):
         `Read in Mattermost API docs (Playbooks - getPlaybooks) <https://api.mattermost.com/#tag/Playbooks/operation/getPlaybooks>`_
 
         """
-        return self.client.get("""/plugins/playbooks/api/v0/playbooks""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "page": page,
+            "per_page": per_page,
+            "sort": sort,
+            "direction": direction,
+            "with_archived": with_archived,
+        }
+        return self.client.get(
+            """/plugins/playbooks/api/v0/playbooks""", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def create_playbook(self, options=None):
+    def create_playbook(
+        self,
+        title: str,
+        team_id: str,
+        create_public_playbook_run: bool,
+        checklists: list[dict[str, Any]],
+        member_ids: list[str],
+        description: str | None = None,
+        public: bool | None = None,
+        broadcast_channel_ids: list[str] | None = None,
+        invited_user_ids: list[str] | None = None,
+        invite_users_enabled: bool | None = None,
+        default_owner_id: str | None = None,
+        default_owner_enabled: str | None = None,
+        announcement_channel_id: str | None = None,
+        announcement_channel_enabled: bool | None = None,
+        webhook_on_creation_url: str | None = None,
+        webhook_on_creation_enabled: bool | None = None,
+        webhook_on_status_update_url: str | None = None,
+        webhook_on_status_update_enabled: bool | None = None,
+    ):
         """Create a playbook
 
         title: The title of the playbook.
@@ -43,9 +82,31 @@ class Playbooks(Base):
         `Read in Mattermost API docs (Playbooks - createPlaybook) <https://api.mattermost.com/#tag/Playbooks/operation/createPlaybook>`_
 
         """
-        return self.client.post("""/plugins/playbooks/api/v0/playbooks""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "title": title,
+            "description": description,
+            "team_id": team_id,
+            "create_public_playbook_run": create_public_playbook_run,
+            "public": public,
+            "checklists": checklists,
+            "member_ids": member_ids,
+            "broadcast_channel_ids": broadcast_channel_ids,
+            "invited_user_ids": invited_user_ids,
+            "invite_users_enabled": invite_users_enabled,
+            "default_owner_id": default_owner_id,
+            "default_owner_enabled": default_owner_enabled,
+            "announcement_channel_id": announcement_channel_id,
+            "announcement_channel_enabled": announcement_channel_enabled,
+            "webhook_on_creation_url": webhook_on_creation_url,
+            "webhook_on_creation_enabled": webhook_on_creation_enabled,
+            "webhook_on_status_update_url": webhook_on_status_update_url,
+            "webhook_on_status_update_enabled": webhook_on_status_update_enabled,
+        }
+        return self.client.post(
+            """/plugins/playbooks/api/v0/playbooks""", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_playbook(self, id):
+    def get_playbook(self, id: str):
         """Get a playbook
 
         id: ID of the playbook to retrieve.
@@ -55,7 +116,7 @@ class Playbooks(Base):
         """
         return self.client.get(f"/plugins/playbooks/api/v0/playbooks/{id}")
 
-    def update_playbook(self, id, options=None):
+    def update_playbook(self, id: str, options: Any | None = None):
         """Update a playbook
 
         id: ID of the playbook to update.
@@ -65,7 +126,7 @@ class Playbooks(Base):
         """
         return self.client.put(f"/plugins/playbooks/api/v0/playbooks/{id}", options=options)
 
-    def delete_playbook(self, id):
+    def delete_playbook(self, id: str):
         """Delete a playbook
 
         id: ID of the playbook to delete.

--- a/src/mattermostautodriver/endpoints/playbooks.py
+++ b/src/mattermostautodriver/endpoints/playbooks.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Playbooks(Base):

--- a/src/mattermostautodriver/endpoints/plugins.py
+++ b/src/mattermostautodriver/endpoints/plugins.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Plugins(Base):
 
-    def upload_plugin(self, files, data=None):
+    def upload_plugin(self, plugin: str, force: str | None = None):
         """Upload plugin
 
         plugin: The plugin image to be uploaded
@@ -12,7 +13,13 @@ class Plugins(Base):
         `Read in Mattermost API docs (plugins - UploadPlugin) <https://api.mattermost.com/#tag/plugins/operation/UploadPlugin>`_
 
         """
-        return self.client.post("""/api/v4/plugins""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"plugin": plugin}
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {"force": force}
+        return self.client.post(
+            """/api/v4/plugins""",
+            files=files_71f8b7431cd64fcfa0dabd300d0636d2,
+            data=data_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
     def get_plugins(self):
         """Get plugins
@@ -28,7 +35,7 @@ class Plugins(Base):
         """
         return self.client.post("""/api/v4/plugins/install_from_url""")
 
-    def remove_plugin(self, plugin_id):
+    def remove_plugin(self, plugin_id: str):
         """Remove plugin
 
         plugin_id: Id of the plugin to be removed
@@ -38,7 +45,7 @@ class Plugins(Base):
         """
         return self.client.delete(f"/api/v4/plugins/{plugin_id}")
 
-    def enable_plugin(self, plugin_id):
+    def enable_plugin(self, plugin_id: str):
         """Enable plugin
 
         plugin_id: Id of the plugin to be enabled
@@ -48,7 +55,7 @@ class Plugins(Base):
         """
         return self.client.post(f"/api/v4/plugins/{plugin_id}/enable")
 
-    def disable_plugin(self, plugin_id):
+    def disable_plugin(self, plugin_id: str):
         """Disable plugin
 
         plugin_id: Id of the plugin to be disabled
@@ -72,7 +79,7 @@ class Plugins(Base):
         """
         return self.client.get("""/api/v4/plugins/statuses""")
 
-    def install_marketplace_plugin(self, options):
+    def install_marketplace_plugin(self, id: str, version: str):
         """Installs a marketplace plugin
 
         id: The ID of the plugin to install.
@@ -81,9 +88,17 @@ class Plugins(Base):
         `Read in Mattermost API docs (plugins - InstallMarketplacePlugin) <https://api.mattermost.com/#tag/plugins/operation/InstallMarketplacePlugin>`_
 
         """
-        return self.client.post("""/api/v4/plugins/marketplace""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"id": id, "version": version}
+        return self.client.post("""/api/v4/plugins/marketplace""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_marketplace_plugins(self, params=None):
+    def get_marketplace_plugins(
+        self,
+        page: int | None = None,
+        per_page: int | None = None,
+        filter: str | None = None,
+        server_version: str | None = None,
+        local_only: bool | None = None,
+    ):
         """Gets all the marketplace plugins
 
         page: Page number to be fetched. (not yet implemented)
@@ -95,7 +110,14 @@ class Plugins(Base):
         `Read in Mattermost API docs (plugins - GetMarketplacePlugins) <https://api.mattermost.com/#tag/plugins/operation/GetMarketplacePlugins>`_
 
         """
-        return self.client.get("""/api/v4/plugins/marketplace""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "filter": filter,
+            "server_version": server_version,
+            "local_only": local_only,
+        }
+        return self.client.get("""/api/v4/plugins/marketplace""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_marketplace_visited_by_admin(self):
         """Get if the Plugin Marketplace has been visited by at least an admin.

--- a/src/mattermostautodriver/endpoints/plugins.py
+++ b/src/mattermostautodriver/endpoints/plugins.py
@@ -1,10 +1,10 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Plugins(Base):
 
-    def upload_plugin(self, plugin: str, force: str | None = None):
+    def upload_plugin(self, plugin: BinaryIO, force: str | None = None):
         """Upload plugin
 
         plugin: The plugin image to be uploaded

--- a/src/mattermostautodriver/endpoints/posts.py
+++ b/src/mattermostautodriver/endpoints/posts.py
@@ -98,10 +98,12 @@ class Posts(Base):
         perPage: The number of posts per page
         fromPost: The post_id to return the next page of posts from
         fromCreateAt: The create_at timestamp to return the next page of posts from
+        fromUpdateAt: The update_at timestamp to return the next page of posts from. You cannot set this flag with direction=down.
         direction: The direction to return the posts. Either up or down.
         skipFetchThreads: Whether to skip fetching threads or not
         collapsedThreads: Whether the client uses CRT or not
         collapsedThreadsExtended: Whether to return the associated users as part of the response or not
+        updatesOnly: This flag is used to make the API work with the updateAt value. If you set this flag, you must set a value for fromUpdateAt.
 
         `Read in Mattermost API docs (posts - GetPostThread) <https://api.mattermost.com/#tag/posts/operation/GetPostThread>`_
 
@@ -263,3 +265,14 @@ class Posts(Base):
 
         """
         return self.client.post(f"/api/v4/posts/{post_id}/move", options=options)
+
+    def restore_post_version(self, post_id, restore_version_id):
+        """Restores a past version of a post
+
+        post_id: The identifier of the post to restore
+        restore_version_id: The identifier of the past version of post to restore to
+
+        `Read in Mattermost API docs (posts - RestorePostVersion) <https://api.mattermost.com/#tag/posts/operation/RestorePostVersion>`_
+
+        """
+        return self.client.post(f"/api/v4/posts/{post_id}/restore/{restore_version_id}")

--- a/src/mattermostautodriver/endpoints/posts.py
+++ b/src/mattermostautodriver/endpoints/posts.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Posts(Base):

--- a/src/mattermostautodriver/endpoints/posts.py
+++ b/src/mattermostautodriver/endpoints/posts.py
@@ -1,9 +1,18 @@
 from .base import Base
+from typing import Any
 
 
 class Posts(Base):
 
-    def create_post(self, options):
+    def create_post(
+        self,
+        channel_id: str,
+        message: str,
+        root_id: str | None = None,
+        file_ids: list[str] | None = None,
+        props: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
         """Create a post
 
         channel_id: The channel ID to post in
@@ -16,9 +25,17 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - CreatePost) <https://api.mattermost.com/#tag/posts/operation/CreatePost>`_
 
         """
-        return self.client.post("""/api/v4/posts""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "channel_id": channel_id,
+            "message": message,
+            "root_id": root_id,
+            "file_ids": file_ids,
+            "props": props,
+            "metadata": metadata,
+        }
+        return self.client.post("""/api/v4/posts""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_post_ephemeral(self, options):
+    def create_post_ephemeral(self, user_id: str, post: dict[str, Any]):
         """Create a ephemeral post
 
         user_id: The target user id for the ephemeral post
@@ -27,9 +44,10 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - CreatePostEphemeral) <https://api.mattermost.com/#tag/posts/operation/CreatePostEphemeral>`_
 
         """
-        return self.client.post("""/api/v4/posts/ephemeral""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"user_id": user_id, "post": post}
+        return self.client.post("""/api/v4/posts/ephemeral""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_post(self, post_id, params=None):
+    def get_post(self, post_id: str, include_deleted: bool | None = False):
         """Get a post
 
         post_id: ID of the post to get
@@ -38,9 +56,10 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - GetPost) <https://api.mattermost.com/#tag/posts/operation/GetPost>`_
 
         """
-        return self.client.get(f"/api/v4/posts/{post_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_deleted": include_deleted}
+        return self.client.get(f"/api/v4/posts/{post_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def delete_post(self, post_id):
+    def delete_post(self, post_id: str):
         """Delete a post
 
         post_id: ID of the post to delete
@@ -50,7 +69,15 @@ class Posts(Base):
         """
         return self.client.delete(f"/api/v4/posts/{post_id}")
 
-    def update_post(self, post_id, options):
+    def update_post(
+        self,
+        post_id: str,
+        id: str,
+        is_pinned: bool | None = None,
+        message: str | None = None,
+        has_reactions: bool | None = None,
+        props: str | None = None,
+    ):
         """Update a post
 
         post_id: ID of the post to update
@@ -63,9 +90,16 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - UpdatePost) <https://api.mattermost.com/#tag/posts/operation/UpdatePost>`_
 
         """
-        return self.client.put(f"/api/v4/posts/{post_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "is_pinned": is_pinned,
+            "message": message,
+            "has_reactions": has_reactions,
+            "props": props,
+        }
+        return self.client.put(f"/api/v4/posts/{post_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def set_post_unread(self, user_id, post_id):
+    def set_post_unread(self, user_id: str, post_id: str):
         """Mark as unread from a post.
 
         user_id: User GUID
@@ -76,7 +110,15 @@ class Posts(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/posts/{post_id}/set_unread")
 
-    def patch_post(self, post_id, options):
+    def patch_post(
+        self,
+        post_id: str,
+        is_pinned: bool | None = None,
+        message: str | None = None,
+        file_ids: list[str] | None = None,
+        has_reactions: bool | None = None,
+        props: str | None = None,
+    ):
         """Patch a post
 
         post_id: Post GUID
@@ -89,9 +131,28 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - PatchPost) <https://api.mattermost.com/#tag/posts/operation/PatchPost>`_
 
         """
-        return self.client.put(f"/api/v4/posts/{post_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "is_pinned": is_pinned,
+            "message": message,
+            "file_ids": file_ids,
+            "has_reactions": has_reactions,
+            "props": props,
+        }
+        return self.client.put(f"/api/v4/posts/{post_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_post_thread(self, post_id, params=None):
+    def get_post_thread(
+        self,
+        post_id: str,
+        perPage: int | None = 0,
+        fromPost: str | None = "",
+        fromCreateAt: int | None = 0,
+        fromUpdateAt: int | None = 0,
+        direction: str | None = "",
+        skipFetchThreads: bool | None = False,
+        collapsedThreads: bool | None = False,
+        collapsedThreadsExtended: bool | None = False,
+        updatesOnly: bool | None = False,
+    ):
         """Get a thread
 
         post_id: ID of a post in the thread
@@ -108,9 +169,27 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - GetPostThread) <https://api.mattermost.com/#tag/posts/operation/GetPostThread>`_
 
         """
-        return self.client.get(f"/api/v4/posts/{post_id}/thread", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "perPage": perPage,
+            "fromPost": fromPost,
+            "fromCreateAt": fromCreateAt,
+            "fromUpdateAt": fromUpdateAt,
+            "direction": direction,
+            "skipFetchThreads": skipFetchThreads,
+            "collapsedThreads": collapsedThreads,
+            "collapsedThreadsExtended": collapsedThreadsExtended,
+            "updatesOnly": updatesOnly,
+        }
+        return self.client.get(f"/api/v4/posts/{post_id}/thread", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_flagged_posts_for_user(self, user_id, params=None):
+    def get_flagged_posts_for_user(
+        self,
+        user_id: str,
+        team_id: str | None = None,
+        channel_id: str | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Get a list of flagged posts
 
         user_id: ID of the user
@@ -122,9 +201,15 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - GetFlaggedPostsForUser) <https://api.mattermost.com/#tag/posts/operation/GetFlaggedPostsForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/posts/flagged", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.get(f"/api/v4/users/{user_id}/posts/flagged", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_file_infos_for_post(self, post_id, params=None):
+    def get_file_infos_for_post(self, post_id: str, include_deleted: bool | None = False):
         """Get file info for post
 
         post_id: ID of the post
@@ -133,9 +218,19 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - GetFileInfosForPost) <https://api.mattermost.com/#tag/posts/operation/GetFileInfosForPost>`_
 
         """
-        return self.client.get(f"/api/v4/posts/{post_id}/files/info", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"include_deleted": include_deleted}
+        return self.client.get(f"/api/v4/posts/{post_id}/files/info", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_posts_for_channel(self, channel_id, params=None):
+    def get_posts_for_channel(
+        self,
+        channel_id: str,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        since: int | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        include_deleted: bool | None = False,
+    ):
         """Get posts for a channel
 
         channel_id: The channel ID to get the posts for
@@ -149,9 +244,26 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - GetPostsForChannel) <https://api.mattermost.com/#tag/posts/operation/GetPostsForChannel>`_
 
         """
-        return self.client.get(f"/api/v4/channels/{channel_id}/posts", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "since": since,
+            "before": before,
+            "after": after,
+            "include_deleted": include_deleted,
+        }
+        return self.client.get(f"/api/v4/channels/{channel_id}/posts", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_posts_around_last_unread(self, user_id, channel_id, params=None):
+    def get_posts_around_last_unread(
+        self,
+        user_id: str,
+        channel_id: str,
+        limit_before: int | None = 60,
+        limit_after: int | None = 60,
+        skipFetchThreads: bool | None = False,
+        collapsedThreads: bool | None = False,
+        collapsedThreadsExtended: bool | None = False,
+    ):
         """Get posts around oldest unread
 
         user_id: ID of the user
@@ -165,9 +277,28 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - GetPostsAroundLastUnread) <https://api.mattermost.com/#tag/posts/operation/GetPostsAroundLastUnread>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/channels/{channel_id}/posts/unread", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "limit_before": limit_before,
+            "limit_after": limit_after,
+            "skipFetchThreads": skipFetchThreads,
+            "collapsedThreads": collapsedThreads,
+            "collapsedThreadsExtended": collapsedThreadsExtended,
+        }
+        return self.client.get(
+            f"/api/v4/users/{user_id}/channels/{channel_id}/posts/unread",
+            params=params_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def search_posts(self, team_id, options):
+    def search_posts(
+        self,
+        team_id: str,
+        terms: str,
+        is_or_search: bool,
+        time_zone_offset: int | None = 0,
+        include_deleted_channels: bool | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Search for team posts
 
         team_id: Team GUID
@@ -181,9 +312,19 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - SearchPosts) <https://api.mattermost.com/#tag/posts/operation/SearchPosts>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/posts/search", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "terms": terms,
+            "is_or_search": is_or_search,
+            "time_zone_offset": time_zone_offset,
+            "include_deleted_channels": include_deleted_channels,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.post(
+            f"/api/v4/teams/{team_id}/posts/search", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def pin_post(self, post_id):
+    def pin_post(self, post_id: str):
         """Pin a post to the channel
 
         post_id: Post GUID
@@ -193,7 +334,7 @@ class Posts(Base):
         """
         return self.client.post(f"/api/v4/posts/{post_id}/pin")
 
-    def unpin_post(self, post_id):
+    def unpin_post(self, post_id: str):
         """Unpin a post to the channel
 
         post_id: Post GUID
@@ -203,7 +344,7 @@ class Posts(Base):
         """
         return self.client.post(f"/api/v4/posts/{post_id}/unpin")
 
-    def do_post_action(self, post_id, action_id):
+    def do_post_action(self, post_id: str, action_id: str):
         """Perform a post action
 
         post_id: Post GUID
@@ -214,14 +355,14 @@ class Posts(Base):
         """
         return self.client.post(f"/api/v4/posts/{post_id}/actions/{action_id}")
 
-    def get_posts_by_ids(self, options):
+    def get_posts_by_ids(self, options: list[str]):
         """Get posts by a list of ids
         `Read in Mattermost API docs (posts - getPostsByIds) <https://api.mattermost.com/#tag/posts/operation/getPostsByIds>`_
 
         """
         return self.client.post("""/api/v4/posts/ids""", options=options)
 
-    def set_post_reminder(self, user_id, post_id, options):
+    def set_post_reminder(self, user_id: str, post_id: str, target_time: int):
         """Set a post reminder
 
         user_id: User GUID
@@ -231,9 +372,12 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - SetPostReminder) <https://api.mattermost.com/#tag/posts/operation/SetPostReminder>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/posts/{post_id}/reminder", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"target_time": target_time}
+        return self.client.post(
+            f"/api/v4/users/{user_id}/posts/{post_id}/reminder", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def save_acknowledgement_for_post(self, user_id, post_id):
+    def save_acknowledgement_for_post(self, user_id: str, post_id: str):
         """Acknowledge a post
 
         user_id: User GUID
@@ -244,7 +388,7 @@ class Posts(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/posts/{post_id}/ack")
 
-    def delete_acknowledgement_for_post(self, user_id, post_id):
+    def delete_acknowledgement_for_post(self, user_id: str, post_id: str):
         """Delete a post acknowledgement
 
         user_id: User GUID
@@ -255,7 +399,7 @@ class Posts(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}/posts/{post_id}/ack")
 
-    def move_thread(self, post_id, options):
+    def move_thread(self, post_id: str, channel_id: str):
         """Move a post (and any posts within that post's thread)
 
         post_id: The identifier of the post to move
@@ -264,9 +408,10 @@ class Posts(Base):
         `Read in Mattermost API docs (posts - MoveThread) <https://api.mattermost.com/#tag/posts/operation/MoveThread>`_
 
         """
-        return self.client.post(f"/api/v4/posts/{post_id}/move", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_id": channel_id}
+        return self.client.post(f"/api/v4/posts/{post_id}/move", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def restore_post_version(self, post_id, restore_version_id):
+    def restore_post_version(self, post_id: str, restore_version_id: str):
         """Restores a past version of a post
 
         post_id: The identifier of the post to restore

--- a/src/mattermostautodriver/endpoints/preferences.py
+++ b/src/mattermostautodriver/endpoints/preferences.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Preferences(Base):
 
-    def get_preferences(self, user_id):
+    def get_preferences(self, user_id: str):
         """Get the user's preferences
 
         user_id: User GUID
@@ -13,7 +14,7 @@ class Preferences(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/preferences")
 
-    def update_preferences(self, user_id, options):
+    def update_preferences(self, user_id: str, options: list[Any]):
         """Save the user's preferences
 
         user_id: User GUID
@@ -23,7 +24,7 @@ class Preferences(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/preferences", options=options)
 
-    def delete_preferences(self, user_id, options):
+    def delete_preferences(self, user_id: str, options: list[Any]):
         """Delete user's preferences
 
         user_id: User GUID
@@ -33,7 +34,7 @@ class Preferences(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/preferences/delete", options=options)
 
-    def get_preferences_by_category(self, user_id, category):
+    def get_preferences_by_category(self, user_id: str, category: str):
         """List a user's preferences by category
 
         user_id: User GUID
@@ -44,7 +45,7 @@ class Preferences(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/preferences/{category}")
 
-    def get_preferences_by_category_by_name(self, user_id, category, preference_name):
+    def get_preferences_by_category_by_name(self, user_id: str, category: str, preference_name: str):
         """Get a specific user preference
 
         user_id: User GUID

--- a/src/mattermostautodriver/endpoints/preferences.py
+++ b/src/mattermostautodriver/endpoints/preferences.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Preferences(Base):

--- a/src/mattermostautodriver/endpoints/reactions.py
+++ b/src/mattermostautodriver/endpoints/reactions.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Reactions(Base):

--- a/src/mattermostautodriver/endpoints/reactions.py
+++ b/src/mattermostautodriver/endpoints/reactions.py
@@ -1,16 +1,17 @@
 from .base import Base
+from typing import Any
 
 
 class Reactions(Base):
 
-    def save_reaction(self, options):
+    def save_reaction(self, options: Any):
         """Create a reaction
         `Read in Mattermost API docs (reactions - SaveReaction) <https://api.mattermost.com/#tag/reactions/operation/SaveReaction>`_
 
         """
         return self.client.post("""/api/v4/reactions""", options=options)
 
-    def get_reactions(self, post_id):
+    def get_reactions(self, post_id: str):
         """Get a list of reactions to a post
 
         post_id: ID of a post
@@ -20,7 +21,7 @@ class Reactions(Base):
         """
         return self.client.get(f"/api/v4/posts/{post_id}/reactions")
 
-    def delete_reaction(self, user_id, post_id, emoji_name):
+    def delete_reaction(self, user_id: str, post_id: str, emoji_name: str):
         """Remove a reaction from a post
 
         user_id: ID of the user
@@ -32,7 +33,7 @@ class Reactions(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}/posts/{post_id}/reactions/{emoji_name}")
 
-    def get_bulk_reactions(self, options):
+    def get_bulk_reactions(self, options: list[str]):
         """Bulk get the reaction for posts
         `Read in Mattermost API docs (reactions - GetBulkReactions) <https://api.mattermost.com/#tag/reactions/operation/GetBulkReactions>`_
 

--- a/src/mattermostautodriver/endpoints/remote_clusters.py
+++ b/src/mattermostautodriver/endpoints/remote_clusters.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class RemoteClusters(Base):

--- a/src/mattermostautodriver/endpoints/remote_clusters.py
+++ b/src/mattermostautodriver/endpoints/remote_clusters.py
@@ -1,9 +1,21 @@
 from .base import Base
+from typing import Any
 
 
 class RemoteClusters(Base):
 
-    def get_remote_clusters(self, params=None):
+    def get_remote_clusters(
+        self,
+        page: int | None = None,
+        per_page: int | None = None,
+        exclude_offline: bool | None = None,
+        in_channel: str | None = None,
+        not_in_channel: str | None = None,
+        only_confirmed: bool | None = None,
+        only_plugins: bool | None = None,
+        exclude_plugins: bool | None = None,
+        include_deleted: bool | None = None,
+    ):
         """Get a list of remote clusters.
 
         page: The page to select
@@ -19,9 +31,22 @@ class RemoteClusters(Base):
         `Read in Mattermost API docs (remote_clusters - GetRemoteClusters) <https://api.mattermost.com/#tag/remote_clusters/operation/GetRemoteClusters>`_
 
         """
-        return self.client.get("""/api/v4/remotecluster""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "exclude_offline": exclude_offline,
+            "in_channel": in_channel,
+            "not_in_channel": not_in_channel,
+            "only_confirmed": only_confirmed,
+            "only_plugins": only_plugins,
+            "exclude_plugins": exclude_plugins,
+            "include_deleted": include_deleted,
+        }
+        return self.client.get("""/api/v4/remotecluster""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_remote_cluster(self, options=None):
+    def create_remote_cluster(
+        self, name: str, default_team_id: str, display_name: str | None = None, password: str | None = None
+    ):
         """Create a new remote cluster.
 
         name:
@@ -35,9 +60,15 @@ class RemoteClusters(Base):
         `Read in Mattermost API docs (remote_clusters - CreateRemoteCluster) <https://api.mattermost.com/#tag/remote_clusters/operation/CreateRemoteCluster>`_
 
         """
-        return self.client.post("""/api/v4/remotecluster""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "name": name,
+            "display_name": display_name,
+            "default_team_id": default_team_id,
+            "password": password,
+        }
+        return self.client.post("""/api/v4/remotecluster""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_remote_cluster(self, remote_id):
+    def get_remote_cluster(self, remote_id: str):
         """Get a remote cluster.
 
         remote_id: Remote Cluster GUID
@@ -47,7 +78,7 @@ class RemoteClusters(Base):
         """
         return self.client.get(f"/api/v4/remotecluster/{remote_id}")
 
-    def patch_remote_cluster(self, remote_id, options=None):
+    def patch_remote_cluster(self, remote_id: str, display_name: str | None = None, default_team_id: str | None = None):
         """Patch a remote cluster.
 
         remote_id: Remote Cluster GUID
@@ -57,9 +88,10 @@ class RemoteClusters(Base):
         `Read in Mattermost API docs (remote_clusters - PatchRemoteCluster) <https://api.mattermost.com/#tag/remote_clusters/operation/PatchRemoteCluster>`_
 
         """
-        return self.client.patch(f"/api/v4/remotecluster/{remote_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"display_name": display_name, "default_team_id": default_team_id}
+        return self.client.patch(f"/api/v4/remotecluster/{remote_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def delete_remote_cluster(self, remote_id):
+    def delete_remote_cluster(self, remote_id: str):
         """Delete a remote cluster.
 
         remote_id: Remote Cluster GUID
@@ -69,7 +101,7 @@ class RemoteClusters(Base):
         """
         return self.client.delete(f"/api/v4/remotecluster/{remote_id}")
 
-    def generate_remote_cluster_invite(self, options=None):
+    def generate_remote_cluster_invite(self, password: str):
         """Generate invite code.
 
         password: The password to encrypt the invite code with.
@@ -77,9 +109,14 @@ class RemoteClusters(Base):
         `Read in Mattermost API docs (remote_clusters - GenerateRemoteClusterInvite) <https://api.mattermost.com/#tag/remote_clusters/operation/GenerateRemoteClusterInvite>`_
 
         """
-        return self.client.post(f"/api/v4/remotecluster/{remote_id}/generate_invite", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"password": password}
+        return self.client.post(
+            f"/api/v4/remotecluster/{remote_id}/generate_invite", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def accept_remote_cluster_invite(self, options=None):
+    def accept_remote_cluster_invite(
+        self, invite: str, name: str, default_team_id: str, password: str, display_name: str | None = None
+    ):
         """Accept a remote cluster invite code.
 
         invite:
@@ -91,4 +128,13 @@ class RemoteClusters(Base):
         `Read in Mattermost API docs (remote_clusters - AcceptRemoteClusterInvite) <https://api.mattermost.com/#tag/remote_clusters/operation/AcceptRemoteClusterInvite>`_
 
         """
-        return self.client.post("""/api/v4/remotecluster/accept_invite""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "invite": invite,
+            "name": name,
+            "display_name": display_name,
+            "default_team_id": default_team_id,
+            "password": password,
+        }
+        return self.client.post(
+            """/api/v4/remotecluster/accept_invite""", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )

--- a/src/mattermostautodriver/endpoints/reports.py
+++ b/src/mattermostautodriver/endpoints/reports.py
@@ -3,6 +3,43 @@ from .base import Base
 
 class Reports(Base):
 
+    def get_users_for_reporting(self, params=None):
+        """Get a list of paged and sorted users for admin reporting purposes
+
+        sort_column: The column to sort the users by. Must be one of ("CreateAt", "Username", "FirstName", "LastName", "Nickname", "Email") or the API will return an error.
+        direction: The direction to accept paging values from. Will return values ahead of the cursor if "prev", and below the cursor if "next". Default is "next".
+        sort_direction: The sorting direction. Must be one of ("asc", "desc"). Will default to 'asc' if not specified or the input is invalid.
+        page_size: The maximum number of users to return.
+        from_column_value: The value of the sorted column corresponding to the cursor to read from. Should be blank for the first page asked for.
+        from_id: The value of the user id corresponding to the cursor to read from. Should be blank for the first page asked for.
+        date_range: The date range of the post statistics to display. Must be one of ("last30days", "previousmonth", "last6months", "alltime"). Will default to 'alltime' if the input is not valid.
+        role_filter: Filter users by their role.
+        team_filter: Filter users by a specified team ID.
+        has_no_team: If true, show only users that have no team. Will ignore provided "team_filter" if true.
+        hide_active: If true, show only users that are inactive. Cannot be used at the same time as "hide_inactive"
+        hide_inactive: If true, show only users that are active. Cannot be used at the same time as "hide_active"
+        search_term: A filtering search term that allows filtering by Username, FirstName, LastName, Nickname or Email
+
+        `Read in Mattermost API docs (reports - GetUsersForReporting) <https://api.mattermost.com/#tag/reports/operation/GetUsersForReporting>`_
+
+        """
+        return self.client.get("""/api/v4/reports/users""", params=params)
+
+    def get_user_count_for_reporting(self, params=None):
+        """Gets the full count of users that match the filter.
+
+        role_filter: Filter users by their role.
+        team_filter: Filter users by a specified team ID.
+        has_no_team: If true, show only users that have no team. Will ignore provided "team_filter" if true.
+        hide_active: If true, show only users that are inactive. Cannot be used at the same time as "hide_inactive"
+        hide_inactive: If true, show only users that are active. Cannot be used at the same time as "hide_active"
+        search_term: A filtering search term that allows filtering by Username, FirstName, LastName, Nickname or Email
+
+        `Read in Mattermost API docs (reports - GetUserCountForReporting) <https://api.mattermost.com/#tag/reports/operation/GetUserCountForReporting>`_
+
+        """
+        return self.client.get("""/api/v4/reports/users/count""", params=params)
+
     def start_batch_users_export(self):
         """Starts a job to export the users to a report file.
         `Read in Mattermost API docs (reports - StartBatchUsersExport) <https://api.mattermost.com/#tag/reports/operation/StartBatchUsersExport>`_

--- a/src/mattermostautodriver/endpoints/reports.py
+++ b/src/mattermostautodriver/endpoints/reports.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Reports(Base):

--- a/src/mattermostautodriver/endpoints/reports.py
+++ b/src/mattermostautodriver/endpoints/reports.py
@@ -1,9 +1,25 @@
 from .base import Base
+from typing import Any
 
 
 class Reports(Base):
 
-    def get_users_for_reporting(self, params=None):
+    def get_users_for_reporting(
+        self,
+        sort_column: str | None = "Username",
+        direction: str | None = "next",
+        sort_direction: str | None = "asc",
+        page_size: int | None = 50,
+        from_column_value: str | None = None,
+        from_id: str | None = None,
+        date_range: str | None = "alltime",
+        role_filter: str | None = None,
+        team_filter: str | None = None,
+        has_no_team: bool | None = None,
+        hide_active: bool | None = None,
+        hide_inactive: bool | None = None,
+        search_term: str | None = None,
+    ):
         """Get a list of paged and sorted users for admin reporting purposes
 
         sort_column: The column to sort the users by. Must be one of ("CreateAt", "Username", "FirstName", "LastName", "Nickname", "Email") or the API will return an error.
@@ -23,9 +39,32 @@ class Reports(Base):
         `Read in Mattermost API docs (reports - GetUsersForReporting) <https://api.mattermost.com/#tag/reports/operation/GetUsersForReporting>`_
 
         """
-        return self.client.get("""/api/v4/reports/users""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "sort_column": sort_column,
+            "direction": direction,
+            "sort_direction": sort_direction,
+            "page_size": page_size,
+            "from_column_value": from_column_value,
+            "from_id": from_id,
+            "date_range": date_range,
+            "role_filter": role_filter,
+            "team_filter": team_filter,
+            "has_no_team": has_no_team,
+            "hide_active": hide_active,
+            "hide_inactive": hide_inactive,
+            "search_term": search_term,
+        }
+        return self.client.get("""/api/v4/reports/users""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user_count_for_reporting(self, params=None):
+    def get_user_count_for_reporting(
+        self,
+        role_filter: str | None = None,
+        team_filter: str | None = None,
+        has_no_team: bool | None = None,
+        hide_active: bool | None = None,
+        hide_inactive: bool | None = None,
+        search_term: str | None = None,
+    ):
         """Gets the full count of users that match the filter.
 
         role_filter: Filter users by their role.
@@ -38,7 +77,15 @@ class Reports(Base):
         `Read in Mattermost API docs (reports - GetUserCountForReporting) <https://api.mattermost.com/#tag/reports/operation/GetUserCountForReporting>`_
 
         """
-        return self.client.get("""/api/v4/reports/users/count""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "role_filter": role_filter,
+            "team_filter": team_filter,
+            "has_no_team": has_no_team,
+            "hide_active": hide_active,
+            "hide_inactive": hide_inactive,
+            "search_term": search_term,
+        }
+        return self.client.get("""/api/v4/reports/users/count""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def start_batch_users_export(self):
         """Starts a job to export the users to a report file.

--- a/src/mattermostautodriver/endpoints/roles.py
+++ b/src/mattermostautodriver/endpoints/roles.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Roles(Base):
@@ -10,7 +11,7 @@ class Roles(Base):
         """
         return self.client.get("""/api/v4/roles""")
 
-    def get_role(self, role_id):
+    def get_role(self, role_id: str):
         """Get a role
 
         role_id: Role GUID
@@ -20,7 +21,7 @@ class Roles(Base):
         """
         return self.client.get(f"/api/v4/roles/{role_id}")
 
-    def get_role_by_name(self, role_name):
+    def get_role_by_name(self, role_name: str):
         """Get a role
 
         role_name: Role Name
@@ -30,7 +31,7 @@ class Roles(Base):
         """
         return self.client.get(f"/api/v4/roles/name/{role_name}")
 
-    def patch_role(self, role_id, options):
+    def patch_role(self, role_id: str, permissions: list[str] | None = None):
         """Patch a role
 
         role_id: Role GUID
@@ -39,9 +40,10 @@ class Roles(Base):
         `Read in Mattermost API docs (roles - PatchRole) <https://api.mattermost.com/#tag/roles/operation/PatchRole>`_
 
         """
-        return self.client.put(f"/api/v4/roles/{role_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"permissions": permissions}
+        return self.client.put(f"/api/v4/roles/{role_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_roles_by_names(self, options):
+    def get_roles_by_names(self, options: list[str]):
         """Get a list of roles by name
         `Read in Mattermost API docs (roles - GetRolesByNames) <https://api.mattermost.com/#tag/roles/operation/GetRolesByNames>`_
 

--- a/src/mattermostautodriver/endpoints/roles.py
+++ b/src/mattermostautodriver/endpoints/roles.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Roles(Base):

--- a/src/mattermostautodriver/endpoints/root.py
+++ b/src/mattermostautodriver/endpoints/root.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Root(Base):

--- a/src/mattermostautodriver/endpoints/root.py
+++ b/src/mattermostautodriver/endpoints/root.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Root(Base):

--- a/src/mattermostautodriver/endpoints/saml.py
+++ b/src/mattermostautodriver/endpoints/saml.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class SAML(Base):
@@ -35,7 +35,7 @@ class SAML(Base):
         options_71f8b7431cd64fcfa0dabd300d0636d2 = {"saml_metadata_url": saml_metadata_url}
         return self.client.post("""/api/v4/saml/metadatafromidp""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def upload_saml_idp_certificate(self, certificate: str):
+    def upload_saml_idp_certificate(self, certificate: BinaryIO):
         """Upload IDP certificate
 
         certificate: The IDP certificate file
@@ -53,7 +53,7 @@ class SAML(Base):
         """
         return self.client.delete("""/api/v4/saml/certificate/idp""")
 
-    def upload_saml_public_certificate(self, certificate: str):
+    def upload_saml_public_certificate(self, certificate: BinaryIO):
         """Upload public certificate
 
         certificate: The public certificate file
@@ -71,7 +71,7 @@ class SAML(Base):
         """
         return self.client.delete("""/api/v4/saml/certificate/public""")
 
-    def upload_saml_private_certificate(self, certificate: str):
+    def upload_saml_private_certificate(self, certificate: BinaryIO):
         """Upload private key
 
         certificate: The private key file

--- a/src/mattermostautodriver/endpoints/saml.py
+++ b/src/mattermostautodriver/endpoints/saml.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class SAML(Base):
 
-    def migrate_auth_to_saml(self, options=None):
+    def migrate_auth_to_saml(self, from_: str, matches: dict[str, Any], auto: bool):
         """Migrate user accounts authentication type to SAML.
 
         from: The current authentication type for the matched users.
@@ -13,7 +14,8 @@ class SAML(Base):
         `Read in Mattermost API docs (SAML - MigrateAuthToSaml) <https://api.mattermost.com/#tag/SAML/operation/MigrateAuthToSaml>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "matches": matches, "auto": auto}
+        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_saml_metadata(self):
         """Get metadata
@@ -22,7 +24,7 @@ class SAML(Base):
         """
         return self.client.get("""/api/v4/saml/metadata""")
 
-    def get_saml_metadata_from_idp(self, options=None):
+    def get_saml_metadata_from_idp(self, saml_metadata_url: str | None = None):
         """Get metadata from Identity Provider
 
         saml_metadata_url: The URL from which to retrieve the SAML IDP data.
@@ -30,9 +32,10 @@ class SAML(Base):
         `Read in Mattermost API docs (SAML - GetSamlMetadataFromIdp) <https://api.mattermost.com/#tag/SAML/operation/GetSamlMetadataFromIdp>`_
 
         """
-        return self.client.post("""/api/v4/saml/metadatafromidp""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"saml_metadata_url": saml_metadata_url}
+        return self.client.post("""/api/v4/saml/metadatafromidp""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def upload_saml_idp_certificate(self, files, data=None):
+    def upload_saml_idp_certificate(self, certificate: str):
         """Upload IDP certificate
 
         certificate: The IDP certificate file
@@ -40,7 +43,8 @@ class SAML(Base):
         `Read in Mattermost API docs (SAML - UploadSamlIdpCertificate) <https://api.mattermost.com/#tag/SAML/operation/UploadSamlIdpCertificate>`_
 
         """
-        return self.client.post("""/api/v4/saml/certificate/idp""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"certificate": certificate}
+        return self.client.post("""/api/v4/saml/certificate/idp""", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def delete_saml_idp_certificate(self):
         """Remove IDP certificate
@@ -49,7 +53,7 @@ class SAML(Base):
         """
         return self.client.delete("""/api/v4/saml/certificate/idp""")
 
-    def upload_saml_public_certificate(self, files, data=None):
+    def upload_saml_public_certificate(self, certificate: str):
         """Upload public certificate
 
         certificate: The public certificate file
@@ -57,7 +61,8 @@ class SAML(Base):
         `Read in Mattermost API docs (SAML - UploadSamlPublicCertificate) <https://api.mattermost.com/#tag/SAML/operation/UploadSamlPublicCertificate>`_
 
         """
-        return self.client.post("""/api/v4/saml/certificate/public""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"certificate": certificate}
+        return self.client.post("""/api/v4/saml/certificate/public""", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def delete_saml_public_certificate(self):
         """Remove public certificate
@@ -66,7 +71,7 @@ class SAML(Base):
         """
         return self.client.delete("""/api/v4/saml/certificate/public""")
 
-    def upload_saml_private_certificate(self, files, data=None):
+    def upload_saml_private_certificate(self, certificate: str):
         """Upload private key
 
         certificate: The private key file
@@ -74,7 +79,8 @@ class SAML(Base):
         `Read in Mattermost API docs (SAML - UploadSamlPrivateCertificate) <https://api.mattermost.com/#tag/SAML/operation/UploadSamlPrivateCertificate>`_
 
         """
-        return self.client.post("""/api/v4/saml/certificate/private""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"certificate": certificate}
+        return self.client.post("""/api/v4/saml/certificate/private""", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def delete_saml_private_certificate(self):
         """Remove private key
@@ -90,7 +96,9 @@ class SAML(Base):
         """
         return self.client.get("""/api/v4/saml/certificate/status""")
 
-    def reset_saml_auth_data_to_email(self, options=None):
+    def reset_saml_auth_data_to_email(
+        self, include_deleted: bool | None = False, dry_run: bool | None = False, user_ids: list[str] | None = []
+    ):
         """Reset AuthData to Email
 
         include_deleted: Whether to include deleted users.
@@ -100,4 +108,9 @@ class SAML(Base):
         `Read in Mattermost API docs (SAML - ResetSamlAuthDataToEmail) <https://api.mattermost.com/#tag/SAML/operation/ResetSamlAuthDataToEmail>`_
 
         """
-        return self.client.post("""/api/v4/saml/reset_auth_data""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "include_deleted": include_deleted,
+            "dry_run": dry_run,
+            "user_ids": user_ids,
+        }
+        return self.client.post("""/api/v4/saml/reset_auth_data""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/scheduled_post.py
+++ b/src/mattermostautodriver/endpoints/scheduled_post.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class ScheduledPost(Base):

--- a/src/mattermostautodriver/endpoints/scheduled_post.py
+++ b/src/mattermostautodriver/endpoints/scheduled_post.py
@@ -1,9 +1,18 @@
 from .base import Base
+from typing import Any
 
 
 class ScheduledPost(Base):
 
-    def create_scheduled_post(self, options=None):
+    def create_scheduled_post(
+        self,
+        scheduled_at: int,
+        channel_id: str,
+        message: str,
+        root_id: str | None = None,
+        file_ids: list[Any] | None = None,
+        props: dict[str, Any] | None = None,
+    ):
         """Creates a scheduled post
 
         scheduled_at: UNIX timestamp in milliseconds of the time when the scheduled post should be sent
@@ -16,9 +25,17 @@ class ScheduledPost(Base):
         `Read in Mattermost API docs (scheduled_post - CreateScheduledPost) <https://api.mattermost.com/#tag/scheduled_post/operation/CreateScheduledPost>`_
 
         """
-        return self.client.post("""/api/v4/posts/schedule""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "scheduled_at": scheduled_at,
+            "channel_id": channel_id,
+            "message": message,
+            "root_id": root_id,
+            "file_ids": file_ids,
+            "props": props,
+        }
+        return self.client.post("""/api/v4/posts/schedule""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user_scheduled_posts(self, params=None):
+    def get_user_scheduled_posts(self, includeDirectChannels: bool | None = False):
         """Gets all scheduled posts for a user for the specified team..
 
         includeDirectChannels: Whether to include scheduled posts from DMs an GMs or not. Default is false
@@ -26,9 +43,14 @@ class ScheduledPost(Base):
         `Read in Mattermost API docs (scheduled_post - GetUserScheduledPosts) <https://api.mattermost.com/#tag/scheduled_post/operation/GetUserScheduledPosts>`_
 
         """
-        return self.client.get(f"/api/v4/posts/scheduled/team/{team_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"includeDirectChannels": includeDirectChannels}
+        return self.client.get(
+            f"/api/v4/posts/scheduled/team/{team_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_scheduled_post(self, scheduled_post_id, options=None):
+    def update_scheduled_post(
+        self, scheduled_post_id: str, id: str, channel_id: str, user_id: str, scheduled_at: int, message: str
+    ):
         """Update a scheduled post
 
         scheduled_post_id: ID of the scheduled post to update
@@ -41,9 +63,18 @@ class ScheduledPost(Base):
         `Read in Mattermost API docs (scheduled_post - UpdateScheduledPost) <https://api.mattermost.com/#tag/scheduled_post/operation/UpdateScheduledPost>`_
 
         """
-        return self.client.put(f"/api/v4/posts/schedule/{scheduled_post_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "channel_id": channel_id,
+            "user_id": user_id,
+            "scheduled_at": scheduled_at,
+            "message": message,
+        }
+        return self.client.put(
+            f"/api/v4/posts/schedule/{scheduled_post_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def delete_scheduled_post(self, scheduled_post_id):
+    def delete_scheduled_post(self, scheduled_post_id: str):
         """Delete a scheduled post
 
         scheduled_post_id: ID of the scheduled post to delete

--- a/src/mattermostautodriver/endpoints/schemes.py
+++ b/src/mattermostautodriver/endpoints/schemes.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Schemes(Base):
 
-    def get_schemes(self, params=None):
+    def get_schemes(self, scope: str | None = "", page: int | None = 0, per_page: int | None = 60):
         """Get the schemes.
 
         scope: Limit the results returned to the provided scope, either ``team`` or ``channel``.
@@ -13,9 +14,10 @@ class Schemes(Base):
         `Read in Mattermost API docs (schemes - GetSchemes) <https://api.mattermost.com/#tag/schemes/operation/GetSchemes>`_
 
         """
-        return self.client.get("""/api/v4/schemes""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"scope": scope, "page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/schemes""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_scheme(self, options):
+    def create_scheme(self, display_name: str, scope: str, name: str | None = None, description: str | None = None):
         """Create a scheme
 
         name: The name of the scheme
@@ -26,9 +28,15 @@ class Schemes(Base):
         `Read in Mattermost API docs (schemes - CreateScheme) <https://api.mattermost.com/#tag/schemes/operation/CreateScheme>`_
 
         """
-        return self.client.post("""/api/v4/schemes""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "name": name,
+            "display_name": display_name,
+            "description": description,
+            "scope": scope,
+        }
+        return self.client.post("""/api/v4/schemes""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_scheme(self, scheme_id):
+    def get_scheme(self, scheme_id: str):
         """Get a scheme
 
         scheme_id: Scheme GUID
@@ -38,7 +46,7 @@ class Schemes(Base):
         """
         return self.client.get(f"/api/v4/schemes/{scheme_id}")
 
-    def delete_scheme(self, scheme_id):
+    def delete_scheme(self, scheme_id: str):
         """Delete a scheme
 
         scheme_id: ID of the scheme to delete
@@ -48,7 +56,7 @@ class Schemes(Base):
         """
         return self.client.delete(f"/api/v4/schemes/{scheme_id}")
 
-    def patch_scheme(self, scheme_id, options):
+    def patch_scheme(self, scheme_id: str, name: str | None = None, description: str | None = None):
         """Patch a scheme
 
         scheme_id: Scheme GUID
@@ -58,9 +66,10 @@ class Schemes(Base):
         `Read in Mattermost API docs (schemes - PatchScheme) <https://api.mattermost.com/#tag/schemes/operation/PatchScheme>`_
 
         """
-        return self.client.put(f"/api/v4/schemes/{scheme_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name, "description": description}
+        return self.client.put(f"/api/v4/schemes/{scheme_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_teams_for_scheme(self, scheme_id, params=None):
+    def get_teams_for_scheme(self, scheme_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get a page of teams which use this scheme.
 
         scheme_id: Scheme GUID
@@ -70,9 +79,10 @@ class Schemes(Base):
         `Read in Mattermost API docs (schemes - GetTeamsForScheme) <https://api.mattermost.com/#tag/schemes/operation/GetTeamsForScheme>`_
 
         """
-        return self.client.get(f"/api/v4/schemes/{scheme_id}/teams", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/schemes/{scheme_id}/teams", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_channels_for_scheme(self, scheme_id, params=None):
+    def get_channels_for_scheme(self, scheme_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get a page of channels which use this scheme.
 
         scheme_id: Scheme GUID
@@ -82,4 +92,5 @@ class Schemes(Base):
         `Read in Mattermost API docs (schemes - GetChannelsForScheme) <https://api.mattermost.com/#tag/schemes/operation/GetChannelsForScheme>`_
 
         """
-        return self.client.get(f"/api/v4/schemes/{scheme_id}/channels", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/schemes/{scheme_id}/channels", params=params_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/schemes.py
+++ b/src/mattermostautodriver/endpoints/schemes.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Schemes(Base):

--- a/src/mattermostautodriver/endpoints/search.py
+++ b/src/mattermostautodriver/endpoints/search.py
@@ -1,9 +1,19 @@
 from .base import Base
+from typing import Any
 
 
 class Search(Base):
 
-    def search_files(self, team_id, data):
+    def search_files(
+        self,
+        team_id: str,
+        terms: str,
+        is_or_search: bool,
+        time_zone_offset: int | None = 0,
+        include_deleted_channels: bool | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Search files in a team
 
         team_id: Team GUID
@@ -17,9 +27,25 @@ class Search(Base):
         `Read in Mattermost API docs (search - SearchFiles) <https://api.mattermost.com/#tag/search/operation/SearchFiles>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/files/search", data=data)
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "terms": terms,
+            "is_or_search": is_or_search,
+            "time_zone_offset": time_zone_offset,
+            "include_deleted_channels": include_deleted_channels,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.post(f"/api/v4/teams/{team_id}/files/search", data=data_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def search_files(self, data):
+    def search_files(
+        self,
+        terms: str,
+        is_or_search: bool,
+        time_zone_offset: int | None = 0,
+        include_deleted_channels: bool | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Search files across the teams of the current user
 
         terms: The search terms as entered by the user. To search for files from a user include ``from:someusername``, using a user's username. To search in a specific channel include ``in:somechannel``, using the channel name (not the display name). To search for specific extensions include ``ext:extension``.
@@ -32,4 +58,12 @@ class Search(Base):
         `Read in Mattermost API docs (search - SearchFiles) <https://api.mattermost.com/#tag/search/operation/SearchFiles>`_
 
         """
-        return self.client.post("""/api/v4/files/search""", data=data)
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "terms": terms,
+            "is_or_search": is_or_search,
+            "time_zone_offset": time_zone_offset,
+            "include_deleted_channels": include_deleted_channels,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.post("""/api/v4/files/search""", data=data_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/search.py
+++ b/src/mattermostautodriver/endpoints/search.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Search(Base):

--- a/src/mattermostautodriver/endpoints/shared_channels.py
+++ b/src/mattermostautodriver/endpoints/shared_channels.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class SharedChannels(Base):
 
-    def get_all_shared_channels(self, team_id, params=None):
+    def get_all_shared_channels(self, team_id: str, page: int | None = 0, per_page: int | None = 0):
         """Get all shared channels for team.
 
         team_id: Team Id
@@ -13,9 +14,20 @@ class SharedChannels(Base):
         `Read in Mattermost API docs (shared_channels - GetAllSharedChannels) <https://api.mattermost.com/#tag/shared_channels/operation/GetAllSharedChannels>`_
 
         """
-        return self.client.get(f"/api/v4/sharedchannels/{team_id}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/sharedchannels/{team_id}", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_shared_channel_remotes_by_remote_cluster(self, remote_id, params=None):
+    def get_shared_channel_remotes_by_remote_cluster(
+        self,
+        remote_id: str,
+        include_unconfirmed: bool | None = None,
+        exclude_confirmed: bool | None = None,
+        exclude_home: bool | None = None,
+        exclude_remote: bool | None = None,
+        include_deleted: bool | None = None,
+        page: int | None = None,
+        per_page: int | None = None,
+    ):
         """Get shared channel remotes by remote cluster.
 
         remote_id: The remote cluster GUID
@@ -30,9 +42,20 @@ class SharedChannels(Base):
         `Read in Mattermost API docs (shared_channels - GetSharedChannelRemotesByRemoteCluster) <https://api.mattermost.com/#tag/shared_channels/operation/GetSharedChannelRemotesByRemoteCluster>`_
 
         """
-        return self.client.get(f"/api/v4/remotecluster/{remote_id}/sharedchannelremotes", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "include_unconfirmed": include_unconfirmed,
+            "exclude_confirmed": exclude_confirmed,
+            "exclude_home": exclude_home,
+            "exclude_remote": exclude_remote,
+            "include_deleted": include_deleted,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.get(
+            f"/api/v4/remotecluster/{remote_id}/sharedchannelremotes", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_remote_cluster_info(self, remote_id):
+    def get_remote_cluster_info(self, remote_id: str):
         """Get remote cluster info by ID for user.
 
         remote_id: Remote Cluster GUID
@@ -42,7 +65,7 @@ class SharedChannels(Base):
         """
         return self.client.get(f"/api/v4/sharedchannels/remote_info/{remote_id}")
 
-    def invite_remote_cluster_to_channel(self, remote_id, channel_id):
+    def invite_remote_cluster_to_channel(self, remote_id: str, channel_id: str):
         """Invites a remote cluster to a channel.
 
         remote_id: The remote cluster GUID
@@ -53,7 +76,7 @@ class SharedChannels(Base):
         """
         return self.client.post(f"/api/v4/remotecluster/{remote_id}/channels/{channel_id}/invite")
 
-    def uninvite_remote_cluster_to_channel(self, remote_id, channel_id):
+    def uninvite_remote_cluster_to_channel(self, remote_id: str, channel_id: str):
         """Uninvites a remote cluster to a channel.
 
         remote_id: The remote cluster GUID

--- a/src/mattermostautodriver/endpoints/shared_channels.py
+++ b/src/mattermostautodriver/endpoints/shared_channels.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class SharedChannels(Base):

--- a/src/mattermostautodriver/endpoints/status.py
+++ b/src/mattermostautodriver/endpoints/status.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Status(Base):
 
-    def get_user_status(self, user_id):
+    def get_user_status(self, user_id: str):
         """Get user status
 
         user_id: User ID
@@ -13,7 +14,7 @@ class Status(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/status")
 
-    def update_user_status(self, user_id, options):
+    def update_user_status(self, user_id: str, user_id: str, status: str, dnd_end_time: int | None = None):
         """Update user status
 
         user_id: User ID
@@ -24,16 +25,19 @@ class Status(Base):
         `Read in Mattermost API docs (status - UpdateUserStatus) <https://api.mattermost.com/#tag/status/operation/UpdateUserStatus>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/status", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"user_id": user_id, "status": status, "dnd_end_time": dnd_end_time}
+        return self.client.put(f"/api/v4/users/{user_id}/status", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_users_statuses_by_ids(self, options):
+    def get_users_statuses_by_ids(self, options: list[str]):
         """Get user statuses by id
         `Read in Mattermost API docs (status - GetUsersStatusesByIds) <https://api.mattermost.com/#tag/status/operation/GetUsersStatusesByIds>`_
 
         """
         return self.client.post("""/api/v4/users/status/ids""", options=options)
 
-    def update_user_custom_status(self, user_id, options):
+    def update_user_custom_status(
+        self, user_id: str, emoji: str, text: str, duration: str | None = None, expires_at: str | None = None
+    ):
         """Update user custom status
 
         user_id: User ID
@@ -45,9 +49,17 @@ class Status(Base):
         `Read in Mattermost API docs (status - UpdateUserCustomStatus) <https://api.mattermost.com/#tag/status/operation/UpdateUserCustomStatus>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/status/custom", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "emoji": emoji,
+            "text": text,
+            "duration": duration,
+            "expires_at": expires_at,
+        }
+        return self.client.put(
+            f"/api/v4/users/{user_id}/status/custom", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def unset_user_custom_status(self, user_id):
+    def unset_user_custom_status(self, user_id: str):
         """Unsets user custom status
 
         user_id: User ID
@@ -57,7 +69,7 @@ class Status(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}/status/custom")
 
-    def remove_recent_custom_status(self, user_id, params):
+    def remove_recent_custom_status(self, user_id: str, emoji: str, text: str, duration: str, expires_at: str):
         """Delete user's recent custom status
 
         user_id: User ID
@@ -69,9 +81,19 @@ class Status(Base):
         `Read in Mattermost API docs (status - RemoveRecentCustomStatus) <https://api.mattermost.com/#tag/status/operation/RemoveRecentCustomStatus>`_
 
         """
-        return self.client.delete(f"/api/v4/users/{user_id}/status/custom/recent", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "emoji": emoji,
+            "text": text,
+            "duration": duration,
+            "expires_at": expires_at,
+        }
+        return self.client.delete(
+            f"/api/v4/users/{user_id}/status/custom/recent", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def post_user_recent_custom_status_delete(self, user_id, options):
+    def post_user_recent_custom_status_delete(
+        self, user_id: str, emoji: str, text: str, duration: str, expires_at: str
+    ):
         """Delete user's recent custom status
 
         user_id: User ID
@@ -83,4 +105,12 @@ class Status(Base):
         `Read in Mattermost API docs (status - PostUserRecentCustomStatusDelete) <https://api.mattermost.com/#tag/status/operation/PostUserRecentCustomStatusDelete>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/status/custom/recent/delete", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "emoji": emoji,
+            "text": text,
+            "duration": duration,
+            "expires_at": expires_at,
+        }
+        return self.client.post(
+            f"/api/v4/users/{user_id}/status/custom/recent/delete", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )

--- a/src/mattermostautodriver/endpoints/status.py
+++ b/src/mattermostautodriver/endpoints/status.py
@@ -14,7 +14,7 @@ class Status(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/status")
 
-    def update_user_status(self, user_id: str, user_id: str, status: str, dnd_end_time: int | None = None):
+    def update_user_status(self, user_id: str, status: str, dnd_end_time: int | None = None):
         """Update user status
 
         user_id: User ID

--- a/src/mattermostautodriver/endpoints/status.py
+++ b/src/mattermostautodriver/endpoints/status.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Status(Base):

--- a/src/mattermostautodriver/endpoints/system.py
+++ b/src/mattermostautodriver/endpoints/system.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class System(Base):
@@ -150,7 +150,7 @@ class System(Base):
         """
         return self.client.put("""/api/v4/config/patch""", options=options)
 
-    def upload_license_file(self, license: str):
+    def upload_license_file(self, license: BinaryIO):
         """Upload license file
 
         license: The license to be uploaded

--- a/src/mattermostautodriver/endpoints/system.py
+++ b/src/mattermostautodriver/endpoints/system.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class System(Base):
@@ -10,7 +11,12 @@ class System(Base):
         """
         return self.client.get("""/api/v4/system/timezones""")
 
-    def get_ping(self, params=None):
+    def get_ping(
+        self,
+        get_server_status: bool | None = None,
+        device_id: str | None = None,
+        use_rest_semantics: bool | None = None,
+    ):
         """Check system health
 
         get_server_status: Check the status of the database and file storage as well
@@ -20,9 +26,14 @@ class System(Base):
         `Read in Mattermost API docs (system - GetPing) <https://api.mattermost.com/#tag/system/operation/GetPing>`_
 
         """
-        return self.client.get("""/api/v4/system/ping""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "get_server_status": get_server_status,
+            "device_id": device_id,
+            "use_rest_semantics": use_rest_semantics,
+        }
+        return self.client.get("""/api/v4/system/ping""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_notices(self, teamId, params=None):
+    def get_notices(self, teamId: str, clientVersion: str, client: str, locale: str | None = None):
         """Get notices for logged in user in specified team
 
         teamId: ID of the team
@@ -33,9 +44,10 @@ class System(Base):
         `Read in Mattermost API docs (system - GetNotices) <https://api.mattermost.com/#tag/system/operation/GetNotices>`_
 
         """
-        return self.client.get(f"/api/v4/system/notices/{teamId}", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"clientVersion": clientVersion, "locale": locale, "client": client}
+        return self.client.get(f"/api/v4/system/notices/{teamId}", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def mark_notices_viewed(self, options):
+    def mark_notices_viewed(self, options: list[str]):
         """Update notices as 'viewed'
         `Read in Mattermost API docs (system - MarkNoticesViewed) <https://api.mattermost.com/#tag/system/operation/MarkNoticesViewed>`_
 
@@ -49,7 +61,7 @@ class System(Base):
         """
         return self.client.post("""/api/v4/database/recycle""")
 
-    def test_email(self, options):
+    def test_email(self, options: Any):
         """Send a test email
         `Read in Mattermost API docs (system - TestEmail) <https://api.mattermost.com/#tag/system/operation/TestEmail>`_
 
@@ -63,7 +75,7 @@ class System(Base):
         """
         return self.client.post("""/api/v4/notifications/test""")
 
-    def test_site_url(self, options):
+    def test_site_url(self, site_url: str):
         """Checks the validity of a Site URL
 
         site_url: The Site URL to test
@@ -71,16 +83,17 @@ class System(Base):
         `Read in Mattermost API docs (system - TestSiteURL) <https://api.mattermost.com/#tag/system/operation/TestSiteURL>`_
 
         """
-        return self.client.post("""/api/v4/site_url/test""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"site_url": site_url}
+        return self.client.post("""/api/v4/site_url/test""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def test_s3_connection(self, options):
+    def test_s3_connection(self, options: Any):
         """Test AWS S3 connection
         `Read in Mattermost API docs (system - TestS3Connection) <https://api.mattermost.com/#tag/system/operation/TestS3Connection>`_
 
         """
         return self.client.post("""/api/v4/file/s3_test""", options=options)
 
-    def get_config(self, params=None):
+    def get_config(self, remove_masked: bool | None = False, remove_defaults: str | None = False):
         """Get configuration
 
         remove_masked: Remove masked values from the exported configuration.
@@ -95,9 +108,10 @@ class System(Base):
         `Read in Mattermost API docs (system - GetConfig) <https://api.mattermost.com/#tag/system/operation/GetConfig>`_
 
         """
-        return self.client.get("""/api/v4/config""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"remove_masked": remove_masked, "remove_defaults": remove_defaults}
+        return self.client.get("""/api/v4/config""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_config(self, options):
+    def update_config(self, options: Any):
         """Update configuration
         `Read in Mattermost API docs (system - UpdateConfig) <https://api.mattermost.com/#tag/system/operation/UpdateConfig>`_
 
@@ -111,7 +125,7 @@ class System(Base):
         """
         return self.client.post("""/api/v4/config/reload""")
 
-    def get_client_config(self, params=None):
+    def get_client_config(self, format: str):
         """Get client configuration
 
         format: Must be ``old``, other formats not implemented yet
@@ -119,7 +133,8 @@ class System(Base):
         `Read in Mattermost API docs (system - GetClientConfig) <https://api.mattermost.com/#tag/system/operation/GetClientConfig>`_
 
         """
-        return self.client.get("""/api/v4/config/client""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"format": format}
+        return self.client.get("""/api/v4/config/client""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_environment_config(self):
         """Get configuration made through environment variables
@@ -128,14 +143,14 @@ class System(Base):
         """
         return self.client.get("""/api/v4/config/environment""")
 
-    def patch_config(self, options):
+    def patch_config(self, options: Any):
         """Patch configuration
         `Read in Mattermost API docs (system - PatchConfig) <https://api.mattermost.com/#tag/system/operation/PatchConfig>`_
 
         """
         return self.client.put("""/api/v4/config/patch""", options=options)
 
-    def upload_license_file(self, files, data=None):
+    def upload_license_file(self, license: str):
         """Upload license file
 
         license: The license to be uploaded
@@ -143,7 +158,8 @@ class System(Base):
         `Read in Mattermost API docs (system - UploadLicenseFile) <https://api.mattermost.com/#tag/system/operation/UploadLicenseFile>`_
 
         """
-        return self.client.post("""/api/v4/license""", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"license": license}
+        return self.client.post("""/api/v4/license""", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def remove_license_file(self):
         """Remove license file
@@ -152,7 +168,7 @@ class System(Base):
         """
         return self.client.delete("""/api/v4/license""")
 
-    def get_client_license(self, params=None):
+    def get_client_license(self, format: str):
         """Get client license
 
         format: Must be ``old``, other formats not implemented yet
@@ -160,7 +176,8 @@ class System(Base):
         `Read in Mattermost API docs (system - GetClientLicense) <https://api.mattermost.com/#tag/system/operation/GetClientLicense>`_
 
         """
-        return self.client.get("""/api/v4/license/client""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"format": format}
+        return self.client.get("""/api/v4/license/client""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_license_load_metric(self):
         """Get license load metric
@@ -176,7 +193,7 @@ class System(Base):
         """
         return self.client.get("""/api/v4/license/renewal""")
 
-    def request_trial_license(self, options):
+    def request_trial_license(self, users: int):
         """Request and install a trial license for your server
 
         users: Number of users requested (20% extra is going to be added)
@@ -184,7 +201,8 @@ class System(Base):
         `Read in Mattermost API docs (system - RequestTrialLicense) <https://api.mattermost.com/#tag/system/operation/RequestTrialLicense>`_
 
         """
-        return self.client.post("""/api/v4/trial-license""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"users": users}
+        return self.client.post("""/api/v4/trial-license""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_prev_trial_license(self):
         """Get last trial license used
@@ -193,7 +211,7 @@ class System(Base):
         """
         return self.client.get("""/api/v4/trial-license/prev""")
 
-    def get_audits(self, params=None):
+    def get_audits(self, page: int | None = 0, per_page: int | None = 60):
         """Get audits
 
         page: The page to select.
@@ -202,7 +220,8 @@ class System(Base):
         `Read in Mattermost API docs (system - GetAudits) <https://api.mattermost.com/#tag/system/operation/GetAudits>`_
 
         """
-        return self.client.get("""/api/v4/audits""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/audits""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def invalidate_caches(self):
         """Invalidate all the caches
@@ -211,7 +230,7 @@ class System(Base):
         """
         return self.client.post("""/api/v4/caches/invalidate""")
 
-    def get_logs(self, params=None):
+    def get_logs(self, page: int | None = 0, logs_per_page: str | None = "10000"):
         """Get logs
 
         page: The page to select.
@@ -220,9 +239,10 @@ class System(Base):
         `Read in Mattermost API docs (system - GetLogs) <https://api.mattermost.com/#tag/system/operation/GetLogs>`_
 
         """
-        return self.client.get("""/api/v4/logs""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "logs_per_page": logs_per_page}
+        return self.client.get("""/api/v4/logs""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def post_log(self, options):
+    def post_log(self, level: str, message: str):
         """Add log message
 
         level: The error level, ERROR or DEBUG
@@ -231,9 +251,10 @@ class System(Base):
         `Read in Mattermost API docs (system - PostLog) <https://api.mattermost.com/#tag/system/operation/PostLog>`_
 
         """
-        return self.client.post("""/api/v4/logs""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"level": level, "message": message}
+        return self.client.post("""/api/v4/logs""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_analytics_old(self, params=None):
+    def get_analytics_old(self, name: str | None = "standard", team_id: str | None = None):
         """Get analytics
 
         name: Possible values are "standard", "bot_post_counts_day", "post_counts_day", "user_counts_with_posts_day" or "extra_counts"
@@ -242,7 +263,8 @@ class System(Base):
         `Read in Mattermost API docs (system - GetAnalyticsOld) <https://api.mattermost.com/#tag/system/operation/GetAnalyticsOld>`_
 
         """
-        return self.client.get("""/api/v4/analytics/old""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name, "team_id": team_id}
+        return self.client.get("""/api/v4/analytics/old""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def set_server_busy(self):
         """Set the server busy (high load) flag
@@ -265,7 +287,7 @@ class System(Base):
         """
         return self.client.delete("""/api/v4/server_busy""")
 
-    def get_redirect_location(self, params=None):
+    def get_redirect_location(self, url: str):
         """Get redirect location
 
         url: Url to check
@@ -273,7 +295,8 @@ class System(Base):
         `Read in Mattermost API docs (system - GetRedirectLocation) <https://api.mattermost.com/#tag/system/operation/GetRedirectLocation>`_
 
         """
-        return self.client.get("""/api/v4/redirect_location""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"url": url}
+        return self.client.get("""/api/v4/redirect_location""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_image_by_url(self):
         """Get an image by url
@@ -310,7 +333,7 @@ class System(Base):
         """
         return self.client.post("""/api/v4/integrity""")
 
-    def generate_support_packet(self, params=None):
+    def generate_support_packet(self, basic_server_logs: bool | None = None, plugin_packets: str | None = None):
         """Download a zip file which contains helpful and useful information for troubleshooting your mattermost instance.
 
         basic_server_logs: Specifies whether the server should include or exclude log files. Default value is true.
@@ -325,9 +348,13 @@ class System(Base):
         `Read in Mattermost API docs (system - GenerateSupportPacket) <https://api.mattermost.com/#tag/system/operation/GenerateSupportPacket>`_
 
         """
-        return self.client.get("""/api/v4/system/support_packet""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "basic_server_logs": basic_server_logs,
+            "plugin_packets": plugin_packets,
+        }
+        return self.client.get("""/api/v4/system/support_packet""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_marketplace_visited_by_admin(self, options):
+    def update_marketplace_visited_by_admin(self, options: Any):
         """Stores that the Plugin Marketplace has been visited by at least an admin.
         `Read in Mattermost API docs (system - UpdateMarketplaceVisitedByAdmin) <https://api.mattermost.com/#tag/system/operation/UpdateMarketplaceVisitedByAdmin>`_
 

--- a/src/mattermostautodriver/endpoints/system.py
+++ b/src/mattermostautodriver/endpoints/system.py
@@ -80,12 +80,22 @@ class System(Base):
         """
         return self.client.post("""/api/v4/file/s3_test""", options=options)
 
-    def get_config(self):
+    def get_config(self, params=None):
         """Get configuration
+
+        remove_masked: Remove masked values from the exported configuration.
+
+        *Minimum server version*: 10.4.0
+
+        remove_defaults: Remove default values from the exported configuration.
+
+        *Minimum server version*: 10.4.0
+
+
         `Read in Mattermost API docs (system - GetConfig) <https://api.mattermost.com/#tag/system/operation/GetConfig>`_
 
         """
-        return self.client.get("""/api/v4/config""")
+        return self.client.get("""/api/v4/config""", params=params)
 
     def update_config(self, options):
         """Update configuration
@@ -151,6 +161,13 @@ class System(Base):
 
         """
         return self.client.get("""/api/v4/license/client""", params=params)
+
+    def get_license_load_metric(self):
+        """Get license load metric
+        `Read in Mattermost API docs (system - GetLicenseLoadMetric) <https://api.mattermost.com/#tag/system/operation/GetLicenseLoadMetric>`_
+
+        """
+        return self.client.get("""/api/v4/license/load_metric""")
 
     def request_license_renewal_link(self):
         """Request the license renewal link

--- a/src/mattermostautodriver/endpoints/teams.py
+++ b/src/mattermostautodriver/endpoints/teams.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Teams(Base):
 
-    def create_team(self, options):
+    def create_team(self, name: str, display_name: str, type: str):
         """Create a team
 
         name: Unique handler for a team, will be present in the team URL
@@ -13,9 +14,16 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - CreateTeam) <https://api.mattermost.com/#tag/teams/operation/CreateTeam>`_
 
         """
-        return self.client.post("""/api/v4/teams""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"name": name, "display_name": display_name, "type": type}
+        return self.client.post("""/api/v4/teams""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_all_teams(self, params=None):
+    def get_all_teams(
+        self,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        include_total_count: bool | None = False,
+        exclude_policy_constrained: bool | None = False,
+    ):
         """Get teams
 
         page: The page to select.
@@ -27,9 +35,15 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - GetAllTeams) <https://api.mattermost.com/#tag/teams/operation/GetAllTeams>`_
 
         """
-        return self.client.get("""/api/v4/teams""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "include_total_count": include_total_count,
+            "exclude_policy_constrained": exclude_policy_constrained,
+        }
+        return self.client.get("""/api/v4/teams""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_team(self, team_id):
+    def get_team(self, team_id: str):
         """Get a team
 
         team_id: Team GUID
@@ -39,7 +53,17 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/{team_id}")
 
-    def update_team(self, team_id, options):
+    def update_team(
+        self,
+        team_id: str,
+        id: str,
+        display_name: str,
+        description: str,
+        company_name: str,
+        allowed_domains: str,
+        invite_id: str,
+        allow_open_invite: str,
+    ):
         """Update a team
 
         team_id: Team GUID
@@ -54,9 +78,18 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - UpdateTeam) <https://api.mattermost.com/#tag/teams/operation/UpdateTeam>`_
 
         """
-        return self.client.put(f"/api/v4/teams/{team_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "display_name": display_name,
+            "description": description,
+            "company_name": company_name,
+            "allowed_domains": allowed_domains,
+            "invite_id": invite_id,
+            "allow_open_invite": allow_open_invite,
+        }
+        return self.client.put(f"/api/v4/teams/{team_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def soft_delete_team(self, team_id):
+    def soft_delete_team(self, team_id: str):
         """Delete a team
 
         team_id: Team GUID
@@ -66,7 +99,15 @@ class Teams(Base):
         """
         return self.client.delete(f"/api/v4/teams/{team_id}")
 
-    def patch_team(self, team_id, options):
+    def patch_team(
+        self,
+        team_id: str,
+        display_name: str | None = None,
+        description: str | None = None,
+        company_name: str | None = None,
+        invite_id: str | None = None,
+        allow_open_invite: bool | None = None,
+    ):
         """Patch a team
 
         team_id: Team GUID
@@ -79,9 +120,16 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - PatchTeam) <https://api.mattermost.com/#tag/teams/operation/PatchTeam>`_
 
         """
-        return self.client.put(f"/api/v4/teams/{team_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "display_name": display_name,
+            "description": description,
+            "company_name": company_name,
+            "invite_id": invite_id,
+            "allow_open_invite": allow_open_invite,
+        }
+        return self.client.put(f"/api/v4/teams/{team_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_team_privacy(self, team_id, options):
+    def update_team_privacy(self, team_id: str, privacy: str):
         """Update teams's privacy
 
         team_id: Team GUID
@@ -90,9 +138,10 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - UpdateTeamPrivacy) <https://api.mattermost.com/#tag/teams/operation/UpdateTeamPrivacy>`_
 
         """
-        return self.client.put(f"/api/v4/teams/{team_id}/privacy", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"privacy": privacy}
+        return self.client.put(f"/api/v4/teams/{team_id}/privacy", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def restore_team(self, team_id):
+    def restore_team(self, team_id: str):
         """Restore a team
 
         team_id: Team GUID
@@ -102,7 +151,7 @@ class Teams(Base):
         """
         return self.client.post(f"/api/v4/teams/{team_id}/restore")
 
-    def get_team_by_name(self, name):
+    def get_team_by_name(self, name: str):
         """Get a team by name
 
         name: Team Name
@@ -112,7 +161,15 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/name/{name}")
 
-    def search_teams(self, options):
+    def search_teams(
+        self,
+        term: str | None = None,
+        page: str | None = None,
+        per_page: str | None = None,
+        allow_open_invite: bool | None = None,
+        group_constrained: bool | None = None,
+        exclude_policy_constrained: bool | None = False,
+    ):
         """Search teams
 
         term: The search term to match against the name or display name of teams
@@ -133,9 +190,17 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - SearchTeams) <https://api.mattermost.com/#tag/teams/operation/SearchTeams>`_
 
         """
-        return self.client.post("""/api/v4/teams/search""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "term": term,
+            "page": page,
+            "per_page": per_page,
+            "allow_open_invite": allow_open_invite,
+            "group_constrained": group_constrained,
+            "exclude_policy_constrained": exclude_policy_constrained,
+        }
+        return self.client.post("""/api/v4/teams/search""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def team_exists(self, name):
+    def team_exists(self, name: str):
         """Check if team exists
 
         name: Team Name
@@ -145,7 +210,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/name/{name}/exists")
 
-    def get_teams_for_user(self, user_id):
+    def get_teams_for_user(self, user_id: str):
         """Get a user's teams
 
         user_id: User GUID
@@ -155,7 +220,14 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams")
 
-    def get_team_members(self, team_id, params=None):
+    def get_team_members(
+        self,
+        team_id: str,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        sort: str | None = "",
+        exclude_deleted_users: bool | None = False,
+    ):
         """Get team members
 
         team_id: Team GUID
@@ -167,9 +239,15 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - GetTeamMembers) <https://api.mattermost.com/#tag/teams/operation/GetTeamMembers>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "sort": sort,
+            "exclude_deleted_users": exclude_deleted_users,
+        }
+        return self.client.get(f"/api/v4/teams/{team_id}/members", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def add_team_member(self, team_id, options):
+    def add_team_member(self, team_id: str, team_id: str | None = None, user_id: str | None = None):
         """Add user to team
 
         team_id: Team GUID
@@ -179,7 +257,8 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - AddTeamMember) <https://api.mattermost.com/#tag/teams/operation/AddTeamMember>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/members", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"team_id": team_id, "user_id": user_id}
+        return self.client.post(f"/api/v4/teams/{team_id}/members", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def add_team_member_from_invite(self):
         """Add user to team from invite
@@ -188,7 +267,7 @@ class Teams(Base):
         """
         return self.client.post("""/api/v4/teams/members/invite""")
 
-    def add_team_members(self, team_id, options):
+    def add_team_members(self, team_id: str, options: list[Any]):
         """Add multiple users to team
 
         team_id: Team GUID
@@ -198,7 +277,7 @@ class Teams(Base):
         """
         return self.client.post(f"/api/v4/teams/{team_id}/members/batch", options=options)
 
-    def get_team_members_for_user(self, user_id):
+    def get_team_members_for_user(self, user_id: str):
         """Get team members for a user
 
         user_id: User GUID
@@ -208,7 +287,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/members")
 
-    def get_team_member(self, team_id, user_id):
+    def get_team_member(self, team_id: str, user_id: str):
         """Get a team member
 
         team_id: Team GUID
@@ -219,7 +298,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/{team_id}/members/{user_id}")
 
-    def remove_team_member(self, team_id, user_id):
+    def remove_team_member(self, team_id: str, user_id: str):
         """Remove user from team
 
         team_id: Team GUID
@@ -230,7 +309,7 @@ class Teams(Base):
         """
         return self.client.delete(f"/api/v4/teams/{team_id}/members/{user_id}")
 
-    def get_team_members_by_ids(self, team_id, options):
+    def get_team_members_by_ids(self, team_id: str, options: list[str]):
         """Get team members by ids
 
         team_id: Team GUID
@@ -240,7 +319,7 @@ class Teams(Base):
         """
         return self.client.post(f"/api/v4/teams/{team_id}/members/ids", options=options)
 
-    def get_team_stats(self, team_id):
+    def get_team_stats(self, team_id: str):
         """Get a team stats
 
         team_id: Team GUID
@@ -250,7 +329,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/{team_id}/stats")
 
-    def regenerate_team_invite_id(self, team_id):
+    def regenerate_team_invite_id(self, team_id: str):
         """Regenerate the Invite ID from a Team
 
         team_id: Team GUID
@@ -260,7 +339,7 @@ class Teams(Base):
         """
         return self.client.post(f"/api/v4/teams/{team_id}/regenerate_invite_id")
 
-    def get_team_icon(self, team_id):
+    def get_team_icon(self, team_id: str):
         """Get the team icon
 
         team_id: Team GUID
@@ -270,7 +349,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/{team_id}/image")
 
-    def set_team_icon(self, team_id, files, data=None):
+    def set_team_icon(self, team_id: str, image: str):
         """Sets the team icon
 
         team_id: Team GUID
@@ -279,9 +358,10 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - SetTeamIcon) <https://api.mattermost.com/#tag/teams/operation/SetTeamIcon>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/image", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"image": image}
+        return self.client.post(f"/api/v4/teams/{team_id}/image", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def remove_team_icon(self, team_id):
+    def remove_team_icon(self, team_id: str):
         """Remove the team icon
 
         team_id: Team GUID
@@ -291,7 +371,7 @@ class Teams(Base):
         """
         return self.client.delete(f"/api/v4/teams/{team_id}/image")
 
-    def update_team_member_roles(self, team_id, user_id, options):
+    def update_team_member_roles(self, team_id: str, user_id: str, roles: str):
         """Update a team member roles
 
         team_id: Team GUID
@@ -301,9 +381,12 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - UpdateTeamMemberRoles) <https://api.mattermost.com/#tag/teams/operation/UpdateTeamMemberRoles>`_
 
         """
-        return self.client.put(f"/api/v4/teams/{team_id}/members/{user_id}/roles", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"roles": roles}
+        return self.client.put(
+            f"/api/v4/teams/{team_id}/members/{user_id}/roles", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def update_team_member_scheme_roles(self, team_id, user_id, options):
+    def update_team_member_scheme_roles(self, team_id: str, user_id: str, scheme_admin: bool, scheme_user: bool):
         """Update the scheme-derived roles of a team member.
 
         team_id: Team GUID
@@ -314,9 +397,14 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - UpdateTeamMemberSchemeRoles) <https://api.mattermost.com/#tag/teams/operation/UpdateTeamMemberSchemeRoles>`_
 
         """
-        return self.client.put(f"/api/v4/teams/{team_id}/members/{user_id}/schemeRoles", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"scheme_admin": scheme_admin, "scheme_user": scheme_user}
+        return self.client.put(
+            f"/api/v4/teams/{team_id}/members/{user_id}/schemeRoles", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_teams_unread_for_user(self, user_id, params=None):
+    def get_teams_unread_for_user(
+        self, user_id: str, exclude_team: str, include_collapsed_threads: bool | None = False
+    ):
         """Get team unreads for a user
 
         user_id: User GUID
@@ -326,9 +414,13 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - GetTeamsUnreadForUser) <https://api.mattermost.com/#tag/teams/operation/GetTeamsUnreadForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/teams/unread", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "exclude_team": exclude_team,
+            "include_collapsed_threads": include_collapsed_threads,
+        }
+        return self.client.get(f"/api/v4/users/{user_id}/teams/unread", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_team_unread(self, user_id, team_id):
+    def get_team_unread(self, user_id: str, team_id: str):
         """Get unreads for a team
 
         user_id: User GUID
@@ -339,7 +431,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/unread")
 
-    def invite_users_to_team(self, team_id, options):
+    def invite_users_to_team(self, team_id: str, options: list[str]):
         """Invite users to the team by email
 
         team_id: Team GUID
@@ -349,7 +441,7 @@ class Teams(Base):
         """
         return self.client.post(f"/api/v4/teams/{team_id}/invite/email", options=options)
 
-    def invite_guests_to_team(self, team_id, options):
+    def invite_guests_to_team(self, team_id: str, emails: list[str], channels: list[str], message: str | None = None):
         """Invite guests to the team by email
 
         team_id: Team GUID
@@ -360,7 +452,10 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - InviteGuestsToTeam) <https://api.mattermost.com/#tag/teams/operation/InviteGuestsToTeam>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/invite-guests/email", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"emails": emails, "channels": channels, "message": message}
+        return self.client.post(
+            f"/api/v4/teams/{team_id}/invite-guests/email", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
     def invalidate_email_invites(self):
         """Invalidate active email invitations
@@ -369,7 +464,7 @@ class Teams(Base):
         """
         return self.client.delete("""/api/v4/teams/invites/email""")
 
-    def import_team(self, team_id, files, data=None):
+    def import_team(self, team_id: str, file: str, filesize: int, importFrom: str):
         """Import a Team from other application
 
         team_id: Team GUID
@@ -380,9 +475,15 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - ImportTeam) <https://api.mattermost.com/#tag/teams/operation/ImportTeam>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/import", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"file": file}
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {"filesize": filesize, "importFrom": importFrom}
+        return self.client.post(
+            f"/api/v4/teams/{team_id}/import",
+            files=files_71f8b7431cd64fcfa0dabd300d0636d2,
+            data=data_71f8b7431cd64fcfa0dabd300d0636d2,
+        )
 
-    def get_team_invite_info(self, invite_id):
+    def get_team_invite_info(self, invite_id: str):
         """Get invite info for a team
 
         invite_id: Invite id for a team
@@ -392,7 +493,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/invite/{invite_id}")
 
-    def update_team_scheme(self, team_id, options):
+    def update_team_scheme(self, team_id: str, scheme_id: str):
         """Set a team's scheme
 
         team_id: Team GUID
@@ -401,9 +502,12 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - UpdateTeamScheme) <https://api.mattermost.com/#tag/teams/operation/UpdateTeamScheme>`_
 
         """
-        return self.client.put(f"/api/v4/teams/{team_id}/scheme", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"scheme_id": scheme_id}
+        return self.client.put(f"/api/v4/teams/{team_id}/scheme", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def team_members_minus_group_members(self, team_id, params=None):
+    def team_members_minus_group_members(
+        self, team_id: str, group_ids: str = "", page: int | None = 0, per_page: int | None = 0
+    ):
         """Team members minus group members.
 
         team_id: Team GUID
@@ -414,9 +518,21 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - TeamMembersMinusGroupMembers) <https://api.mattermost.com/#tag/teams/operation/TeamMembersMinusGroupMembers>`_
 
         """
-        return self.client.get(f"/api/v4/teams/{team_id}/members_minus_group_members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"group_ids": group_ids, "page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/teams/{team_id}/members_minus_group_members", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def search_files(self, team_id, data):
+    def search_files(
+        self,
+        team_id: str,
+        terms: str,
+        is_or_search: bool,
+        time_zone_offset: int | None = 0,
+        include_deleted_channels: bool | None = None,
+        page: int | None = 0,
+        per_page: int | None = 60,
+    ):
         """Search files in a team
 
         team_id: Team GUID
@@ -430,4 +546,12 @@ class Teams(Base):
         `Read in Mattermost API docs (teams - SearchFiles) <https://api.mattermost.com/#tag/teams/operation/SearchFiles>`_
 
         """
-        return self.client.post(f"/api/v4/teams/{team_id}/files/search", data=data)
+        data_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "terms": terms,
+            "is_or_search": is_or_search,
+            "time_zone_offset": time_zone_offset,
+            "include_deleted_channels": include_deleted_channels,
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.client.post(f"/api/v4/teams/{team_id}/files/search", data=data_71f8b7431cd64fcfa0dabd300d0636d2)

--- a/src/mattermostautodriver/endpoints/teams.py
+++ b/src/mattermostautodriver/endpoints/teams.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Teams(Base):
@@ -349,7 +349,7 @@ class Teams(Base):
         """
         return self.client.get(f"/api/v4/teams/{team_id}/image")
 
-    def set_team_icon(self, team_id: str, image: str):
+    def set_team_icon(self, team_id: str, image: BinaryIO):
         """Sets the team icon
 
         team_id: Team GUID
@@ -464,7 +464,7 @@ class Teams(Base):
         """
         return self.client.delete("""/api/v4/teams/invites/email""")
 
-    def import_team(self, team_id: str, file: str, filesize: int, importFrom: str):
+    def import_team(self, team_id: str, file: BinaryIO, filesize: int, importFrom: str):
         """Import a Team from other application
 
         team_id: Team GUID

--- a/src/mattermostautodriver/endpoints/teams.py
+++ b/src/mattermostautodriver/endpoints/teams.py
@@ -247,7 +247,7 @@ class Teams(Base):
         }
         return self.client.get(f"/api/v4/teams/{team_id}/members", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def add_team_member(self, team_id: str, team_id: str | None = None, user_id: str | None = None):
+    def add_team_member(self, team_id: str, user_id: str | None = None):
         """Add user to team
 
         team_id: Team GUID

--- a/src/mattermostautodriver/endpoints/terms_of_service.py
+++ b/src/mattermostautodriver/endpoints/terms_of_service.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class TermsOfService(Base):
 
-    def register_terms_of_service_action(self, user_id, options):
+    def register_terms_of_service_action(self, user_id: str, serviceTermsId: str, accepted: str):
         """Records user action when they accept or decline custom terms of service
 
         user_id: User GUID
@@ -13,9 +14,12 @@ class TermsOfService(Base):
         `Read in Mattermost API docs (terms_of_service - RegisterTermsOfServiceAction) <https://api.mattermost.com/#tag/terms_of_service/operation/RegisterTermsOfServiceAction>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/terms_of_service", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"serviceTermsId": serviceTermsId, "accepted": accepted}
+        return self.client.post(
+            f"/api/v4/users/{user_id}/terms_of_service", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_user_terms_of_service(self, user_id):
+    def get_user_terms_of_service(self, user_id: str):
         """Fetches user's latest terms of service action if the latest action was for acceptance.
 
         user_id: User GUID

--- a/src/mattermostautodriver/endpoints/terms_of_service.py
+++ b/src/mattermostautodriver/endpoints/terms_of_service.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class TermsOfService(Base):

--- a/src/mattermostautodriver/endpoints/threads.py
+++ b/src/mattermostautodriver/endpoints/threads.py
@@ -1,9 +1,21 @@
 from .base import Base
+from typing import Any
 
 
 class Threads(Base):
 
-    def get_user_threads(self, user_id, team_id, params=None):
+    def get_user_threads(
+        self,
+        user_id: str,
+        team_id: str,
+        since: int | None = None,
+        deleted: bool | None = False,
+        extended: bool | None = False,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        totalsOnly: bool | None = False,
+        threadsOnly: bool | None = False,
+    ):
         """Get all threads that user is following
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -19,9 +31,20 @@ class Threads(Base):
         `Read in Mattermost API docs (threads - GetUserThreads) <https://api.mattermost.com/#tag/threads/operation/GetUserThreads>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/threads", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "since": since,
+            "deleted": deleted,
+            "extended": extended,
+            "page": page,
+            "per_page": per_page,
+            "totalsOnly": totalsOnly,
+            "threadsOnly": threadsOnly,
+        }
+        return self.client.get(
+            f"/api/v4/users/{user_id}/teams/{team_id}/threads", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_thread_mention_counts_by_channel(self, user_id, team_id):
+    def get_thread_mention_counts_by_channel(self, user_id: str, team_id: str):
         """Get all unread mention counts from followed threads, per-channel
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -32,7 +55,7 @@ class Threads(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/teams/{team_id}/threads/mention_counts")
 
-    def update_threads_read_for_user(self, user_id, team_id):
+    def update_threads_read_for_user(self, user_id: str, team_id: str):
         """Mark all threads that user is following as read
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -43,7 +66,7 @@ class Threads(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/teams/{team_id}/threads/read")
 
-    def update_thread_read_for_user(self, user_id, team_id, thread_id, timestamp):
+    def update_thread_read_for_user(self, user_id: str, team_id: str, thread_id: str, timestamp: str):
         """Mark a thread that user is following read state to the timestamp
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -56,7 +79,7 @@ class Threads(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/read/{timestamp}")
 
-    def set_thread_unread_by_post_id(self, user_id, team_id, thread_id, post_id):
+    def set_thread_unread_by_post_id(self, user_id: str, team_id: str, thread_id: str, post_id: str):
         """Mark a thread that user is following as unread based on a post id
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -69,7 +92,7 @@ class Threads(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/set_unread/{post_id}")
 
-    def start_following_thread(self, user_id, team_id, thread_id):
+    def start_following_thread(self, user_id: str, team_id: str, thread_id: str):
         """Start following a thread
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -81,7 +104,7 @@ class Threads(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/following")
 
-    def stop_following_thread(self, user_id, team_id, thread_id):
+    def stop_following_thread(self, user_id: str, team_id: str, thread_id: str):
         """Stop following a thread
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -93,7 +116,7 @@ class Threads(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}/teams/{team_id}/threads/{thread_id}/following")
 
-    def get_user_thread(self, user_id, team_id, thread_id):
+    def get_user_thread(self, user_id: str, team_id: str, thread_id: str):
         """Get a thread followed by the user
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.

--- a/src/mattermostautodriver/endpoints/threads.py
+++ b/src/mattermostautodriver/endpoints/threads.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Threads(Base):

--- a/src/mattermostautodriver/endpoints/timeline.py
+++ b/src/mattermostautodriver/endpoints/timeline.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Timeline(Base):

--- a/src/mattermostautodriver/endpoints/timeline.py
+++ b/src/mattermostautodriver/endpoints/timeline.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Timeline(Base):
 
-    def remove_timeline_event(self, id, event_id):
+    def remove_timeline_event(self, id: str, event_id: str):
         """Remove a timeline event from the playbook run
 
         id: ID of the playbook run whose timeline event will be modified.

--- a/src/mattermostautodriver/endpoints/uploads.py
+++ b/src/mattermostautodriver/endpoints/uploads.py
@@ -1,9 +1,10 @@
 from .base import Base
+from typing import Any
 
 
 class Uploads(Base):
 
-    def create_upload(self, options):
+    def create_upload(self, channel_id: str, filename: str, file_size: int):
         """Create an upload
 
         channel_id: The ID of the channel to upload to.
@@ -13,9 +14,14 @@ class Uploads(Base):
         `Read in Mattermost API docs (uploads - CreateUpload) <https://api.mattermost.com/#tag/uploads/operation/CreateUpload>`_
 
         """
-        return self.client.post("""/api/v4/uploads""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "channel_id": channel_id,
+            "filename": filename,
+            "file_size": file_size,
+        }
+        return self.client.post("""/api/v4/uploads""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_upload(self, upload_id):
+    def get_upload(self, upload_id: str):
         """Get an upload session
 
         upload_id: The ID of the upload session to get.
@@ -25,7 +31,7 @@ class Uploads(Base):
         """
         return self.client.get(f"/api/v4/uploads/{upload_id}")
 
-    def upload_data(self, upload_id, files, options=None):
+    def upload_data(self, upload_id: str, data: dict[str, Any] | None = None):
         """Perform a file upload
 
         upload_id: The ID of the upload session the data belongs to.
@@ -33,4 +39,4 @@ class Uploads(Base):
         `Read in Mattermost API docs (uploads - UploadData) <https://api.mattermost.com/#tag/uploads/operation/UploadData>`_
 
         """
-        return self.client.post(f"/api/v4/uploads/{upload_id}", files=files, options=options)
+        return self.client.post(f"/api/v4/uploads/{upload_id}", data=data)

--- a/src/mattermostautodriver/endpoints/uploads.py
+++ b/src/mattermostautodriver/endpoints/uploads.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Uploads(Base):

--- a/src/mattermostautodriver/endpoints/usage.py
+++ b/src/mattermostautodriver/endpoints/usage.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Usage(Base):

--- a/src/mattermostautodriver/endpoints/usage.py
+++ b/src/mattermostautodriver/endpoints/usage.py
@@ -1,4 +1,5 @@
 from .base import Base
+from typing import Any
 
 
 class Usage(Base):

--- a/src/mattermostautodriver/endpoints/users.py
+++ b/src/mattermostautodriver/endpoints/users.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Users(Base):
@@ -501,7 +501,7 @@ class Users(Base):
         params_71f8b7431cd64fcfa0dabd300d0636d2 = {"_": _}
         return self.client.get(f"/api/v4/users/{user_id}/image", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def set_profile_image(self, user_id: str, image: str):
+    def set_profile_image(self, user_id: str, image: BinaryIO):
         """Set user's profile image
 
         user_id: User GUID

--- a/src/mattermostautodriver/endpoints/users.py
+++ b/src/mattermostautodriver/endpoints/users.py
@@ -748,6 +748,13 @@ class Users(Base):
         """
         return self.client.get("""/api/v4/users/invalid_emails""", params=params)
 
+    def reset_password_failed_attempts(self):
+        """Reset the failed password attempts for a user
+        `Read in Mattermost API docs (users - resetPasswordFailedAttempts) <https://api.mattermost.com/#tag/users/operation/resetPasswordFailedAttempts>`_
+
+        """
+        return self.client.post(f"/api/v4/users/{user_id}/reset_failed_attempts")
+
     def convert_bot_to_user(self, bot_user_id, options):
         """Convert a bot into a user
 
@@ -767,43 +774,6 @@ class Users(Base):
 
         """
         return self.client.post(f"/api/v4/bots/{bot_user_id}/convert_to_user", options=options)
-
-    def get_users_for_reporting(self, params=None):
-        """Get a list of paged and sorted users for admin reporting purposes
-
-        sort_column: The column to sort the users by. Must be one of ("CreateAt", "Username", "FirstName", "LastName", "Nickname", "Email") or the API will return an error.
-        direction: The direction in which to accept paging values from. Will return values ahead of the cursor if "up", and below the cursor if "down". Default is "down".
-        sort_direction: The sorting direction. Must be one of ("asc", "desc"). Will default to 'asc' if not specified or the input is invalid.
-        page_size: The maximum number of users to return.
-        from_column_value: The value of the sorted column corresponding to the cursor to read from. Should be blank for the first page asked for.
-        from_id: The value of the user id corresponding to the cursor to read from. Should be blank for the first page asked for.
-        date_range: The date range of the post statistics to display. Must be one of ("last30days", "previousmonth", "last6months", "alltime"). Will default to 'alltime' if the input is not valid.
-        role_filter: Filter users by their role.
-        team_filter: Filter users by a specified team ID.
-        has_no_team: If true, show only users that have no team. Will ignore provided "team_filter" if true.
-        hide_active: If true, show only users that are inactive. Cannot be used at the same time as "hide_inactive"
-        hide_inactive: If true, show only users that are active. Cannot be used at the same time as "hide_active"
-        search_term: A filtering search term that allows filtering by Username, FirstName, LastName, Nickname or Email
-
-        `Read in Mattermost API docs (users - GetUsersForReporting) <https://api.mattermost.com/#tag/users/operation/GetUsersForReporting>`_
-
-        """
-        return self.client.get("""/api/v4/reports/users""", params=params)
-
-    def get_user_count_for_reporting(self, params=None):
-        """Gets the full count of users that match the filter.
-
-        role_filter: Filter users by their role.
-        team_filter: Filter users by a specified team ID.
-        has_no_team: If true, show only users that have no team. Will ignore provided "team_filter" if true.
-        hide_active: If true, show only users that are inactive. Cannot be used at the same time as "hide_inactive"
-        hide_inactive: If true, show only users that are active. Cannot be used at the same time as "hide_active"
-        search_term: A filtering search term that allows filtering by Username, FirstName, LastName, Nickname or Email
-
-        `Read in Mattermost API docs (users - GetUserCountForReporting) <https://api.mattermost.com/#tag/users/operation/GetUserCountForReporting>`_
-
-        """
-        return self.client.get("""/api/v4/reports/users/count""", params=params)
 
     def get_server_limits(self):
         """Gets the server limits for the server

--- a/src/mattermostautodriver/endpoints/users.py
+++ b/src/mattermostautodriver/endpoints/users.py
@@ -1,9 +1,18 @@
 from .base import Base
+from typing import Any
 
 
 class Users(Base):
 
-    def login(self, options):
+    def login(
+        self,
+        id: str | None = None,
+        login_id: str | None = None,
+        token: str | None = None,
+        device_id: str | None = None,
+        ldap_only: bool | None = None,
+        password: str | None = None,
+    ):
         """Login to Mattermost server
 
         id:
@@ -16,9 +25,17 @@ class Users(Base):
         `Read in Mattermost API docs (users - Login) <https://api.mattermost.com/#tag/users/operation/Login>`_
 
         """
-        return self.client.post("""/api/v4/users/login""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "login_id": login_id,
+            "token": token,
+            "device_id": device_id,
+            "ldap_only": ldap_only,
+            "password": password,
+        }
+        return self.client.post("""/api/v4/users/login""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def login_by_cws_token(self, options):
+    def login_by_cws_token(self, login_id: str | None = None, cws_token: str | None = None):
         """Auto-Login to Mattermost server using CWS token
 
         login_id:
@@ -27,7 +44,8 @@ class Users(Base):
         `Read in Mattermost API docs (users - LoginByCwsToken) <https://api.mattermost.com/#tag/users/operation/LoginByCwsToken>`_
 
         """
-        return self.client.post("""/api/v4/users/login/cws""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"login_id": login_id, "cws_token": cws_token}
+        return self.client.post("""/api/v4/users/login/cws""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def logout(self):
         """Logout from the Mattermost server
@@ -36,7 +54,22 @@ class Users(Base):
         """
         return self.client.post("""/api/v4/users/logout""")
 
-    def create_user(self, options):
+    def create_user(
+        self,
+        email: str,
+        username: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        nickname: str | None = None,
+        position: str | None = None,
+        timezone: Any | None = None,
+        auth_data: str | None = None,
+        auth_service: str | None = None,
+        password: str | None = None,
+        locale: str | None = None,
+        props: dict[str, Any] | None = None,
+        notify_props: Any | None = None,
+    ):
         """Create a user
 
         email:
@@ -56,9 +89,42 @@ class Users(Base):
         `Read in Mattermost API docs (users - CreateUser) <https://api.mattermost.com/#tag/users/operation/CreateUser>`_
 
         """
-        return self.client.post("""/api/v4/users""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "email": email,
+            "username": username,
+            "first_name": first_name,
+            "last_name": last_name,
+            "nickname": nickname,
+            "position": position,
+            "timezone": timezone,
+            "auth_data": auth_data,
+            "auth_service": auth_service,
+            "password": password,
+            "locale": locale,
+            "props": props,
+            "notify_props": notify_props,
+        }
+        return self.client.post("""/api/v4/users""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_users(self, params=None):
+    def get_users(
+        self,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        in_team: str | None = None,
+        not_in_team: str | None = None,
+        in_channel: str | None = None,
+        not_in_channel: str | None = None,
+        in_group: str | None = None,
+        group_constrained: bool | None = None,
+        without_team: bool | None = None,
+        active: bool | None = None,
+        inactive: bool | None = None,
+        role: str | None = None,
+        sort: str | None = None,
+        roles: str | None = None,
+        channel_roles: str | None = None,
+        team_roles: str | None = None,
+    ):
         """Get users
 
         page: The page to select.
@@ -111,7 +177,25 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetUsers) <https://api.mattermost.com/#tag/users/operation/GetUsers>`_
 
         """
-        return self.client.get("""/api/v4/users""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "in_team": in_team,
+            "not_in_team": not_in_team,
+            "in_channel": in_channel,
+            "not_in_channel": not_in_channel,
+            "in_group": in_group,
+            "group_constrained": group_constrained,
+            "without_team": without_team,
+            "active": active,
+            "inactive": inactive,
+            "role": role,
+            "sort": sort,
+            "roles": roles,
+            "channel_roles": channel_roles,
+            "team_roles": team_roles,
+        }
+        return self.client.get("""/api/v4/users""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def permanent_delete_all_users(self):
         """Permanent delete all users
@@ -120,28 +204,40 @@ class Users(Base):
         """
         return self.client.delete("""/api/v4/users""")
 
-    def get_users_by_ids(self, options):
+    def get_users_by_ids(self, options: list[str]):
         """Get users by ids
         `Read in Mattermost API docs (users - GetUsersByIds) <https://api.mattermost.com/#tag/users/operation/GetUsersByIds>`_
 
         """
         return self.client.post("""/api/v4/users/ids""", options=options)
 
-    def get_users_by_group_channel_ids(self, options):
+    def get_users_by_group_channel_ids(self, options: list[str]):
         """Get users by group channels ids
         `Read in Mattermost API docs (users - GetUsersByGroupChannelIds) <https://api.mattermost.com/#tag/users/operation/GetUsersByGroupChannelIds>`_
 
         """
         return self.client.post("""/api/v4/users/group_channels""", options=options)
 
-    def get_users_by_usernames(self, options):
+    def get_users_by_usernames(self, options: list[str]):
         """Get users by usernames
         `Read in Mattermost API docs (users - GetUsersByUsernames) <https://api.mattermost.com/#tag/users/operation/GetUsersByUsernames>`_
 
         """
         return self.client.post("""/api/v4/users/usernames""", options=options)
 
-    def search_users(self, options):
+    def search_users(
+        self,
+        term: str,
+        team_id: str | None = None,
+        not_in_team_id: str | None = None,
+        in_channel_id: str | None = None,
+        not_in_channel_id: str | None = None,
+        in_group_id: str | None = None,
+        group_constrained: bool | None = None,
+        allow_inactive: bool | None = None,
+        without_team: bool | None = None,
+        limit: int | None = 100,
+    ):
         """Search users
 
         term: The term to match against username, full name, nickname and email
@@ -161,9 +257,23 @@ class Users(Base):
         `Read in Mattermost API docs (users - SearchUsers) <https://api.mattermost.com/#tag/users/operation/SearchUsers>`_
 
         """
-        return self.client.post("""/api/v4/users/search""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "term": term,
+            "team_id": team_id,
+            "not_in_team_id": not_in_team_id,
+            "in_channel_id": in_channel_id,
+            "not_in_channel_id": not_in_channel_id,
+            "in_group_id": in_group_id,
+            "group_constrained": group_constrained,
+            "allow_inactive": allow_inactive,
+            "without_team": without_team,
+            "limit": limit,
+        }
+        return self.client.post("""/api/v4/users/search""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def autocomplete_users(self, params=None):
+    def autocomplete_users(
+        self, name: str, team_id: str | None = None, channel_id: str | None = None, limit: int | None = 100
+    ):
         """Autocomplete users
 
         team_id: Team ID
@@ -177,7 +287,13 @@ class Users(Base):
         `Read in Mattermost API docs (users - AutocompleteUsers) <https://api.mattermost.com/#tag/users/operation/AutocompleteUsers>`_
 
         """
-        return self.client.get("""/api/v4/users/autocomplete""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "name": name,
+            "limit": limit,
+        }
+        return self.client.get("""/api/v4/users/autocomplete""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def get_known_users(self):
         """Get user IDs of known users
@@ -193,7 +309,16 @@ class Users(Base):
         """
         return self.client.get("""/api/v4/users/stats""")
 
-    def get_total_users_stats_filtered(self, params=None):
+    def get_total_users_stats_filtered(
+        self,
+        in_team: str | None = None,
+        in_channel: str | None = None,
+        include_deleted: bool | None = None,
+        include_bots: bool | None = None,
+        roles: str | None = None,
+        channel_roles: str | None = None,
+        team_roles: str | None = None,
+    ):
         """Get total count of users in the system matching the specified filters
 
         in_team: The ID of the team to get user stats for.
@@ -216,9 +341,18 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetTotalUsersStatsFiltered) <https://api.mattermost.com/#tag/users/operation/GetTotalUsersStatsFiltered>`_
 
         """
-        return self.client.get("""/api/v4/users/stats/filtered""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "in_team": in_team,
+            "in_channel": in_channel,
+            "include_deleted": include_deleted,
+            "include_bots": include_bots,
+            "roles": roles,
+            "channel_roles": channel_roles,
+            "team_roles": team_roles,
+        }
+        return self.client.get("""/api/v4/users/stats/filtered""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user(self, user_id):
+    def get_user(self, user_id: str):
         """Get a user
 
         user_id: User GUID. This can also be "me" which will point to the current user.
@@ -228,7 +362,21 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}")
 
-    def update_user(self, user_id, options):
+    def update_user(
+        self,
+        user_id: str,
+        id: str,
+        email: str,
+        username: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        nickname: str | None = None,
+        locale: str | None = None,
+        position: str | None = None,
+        timezone: Any | None = None,
+        props: dict[str, Any] | None = None,
+        notify_props: Any | None = None,
+    ):
         """Update a user
 
         user_id: User GUID
@@ -247,9 +395,22 @@ class Users(Base):
         `Read in Mattermost API docs (users - UpdateUser) <https://api.mattermost.com/#tag/users/operation/UpdateUser>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "email": email,
+            "username": username,
+            "first_name": first_name,
+            "last_name": last_name,
+            "nickname": nickname,
+            "locale": locale,
+            "position": position,
+            "timezone": timezone,
+            "props": props,
+            "notify_props": notify_props,
+        }
+        return self.client.put(f"/api/v4/users/{user_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def delete_user(self, user_id):
+    def delete_user(self, user_id: str):
         """Deactivate a user account.
 
         user_id: User GUID
@@ -259,7 +420,20 @@ class Users(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}")
 
-    def patch_user(self, user_id, options):
+    def patch_user(
+        self,
+        user_id: str,
+        email: str | None = None,
+        username: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        nickname: str | None = None,
+        locale: str | None = None,
+        position: str | None = None,
+        timezone: Any | None = None,
+        props: dict[str, Any] | None = None,
+        notify_props: Any | None = None,
+    ):
         """Patch a user
 
         user_id: User GUID
@@ -277,9 +451,21 @@ class Users(Base):
         `Read in Mattermost API docs (users - PatchUser) <https://api.mattermost.com/#tag/users/operation/PatchUser>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/patch", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "email": email,
+            "username": username,
+            "first_name": first_name,
+            "last_name": last_name,
+            "nickname": nickname,
+            "locale": locale,
+            "position": position,
+            "timezone": timezone,
+            "props": props,
+            "notify_props": notify_props,
+        }
+        return self.client.put(f"/api/v4/users/{user_id}/patch", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_user_roles(self, user_id, options):
+    def update_user_roles(self, user_id: str, roles: str):
         """Update a user's roles
 
         user_id: User GUID
@@ -288,9 +474,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - UpdateUserRoles) <https://api.mattermost.com/#tag/users/operation/UpdateUserRoles>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/roles", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"roles": roles}
+        return self.client.put(f"/api/v4/users/{user_id}/roles", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_user_active(self, user_id, options):
+    def update_user_active(self, user_id: str, active: bool):
         """Update user active status
 
         user_id: User GUID
@@ -299,9 +486,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - UpdateUserActive) <https://api.mattermost.com/#tag/users/operation/UpdateUserActive>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/active", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"active": active}
+        return self.client.put(f"/api/v4/users/{user_id}/active", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_profile_image(self, user_id, params=None):
+    def get_profile_image(self, user_id: str, _: float | None = None):
         """Get user's profile image
 
         user_id: User GUID
@@ -310,9 +498,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetProfileImage) <https://api.mattermost.com/#tag/users/operation/GetProfileImage>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/image", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"_": _}
+        return self.client.get(f"/api/v4/users/{user_id}/image", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def set_profile_image(self, user_id, files, data=None):
+    def set_profile_image(self, user_id: str, image: str):
         """Set user's profile image
 
         user_id: User GUID
@@ -321,9 +510,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - SetProfileImage) <https://api.mattermost.com/#tag/users/operation/SetProfileImage>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/image", files=files, data=data)
+        files_71f8b7431cd64fcfa0dabd300d0636d2 = {"image": image}
+        return self.client.post(f"/api/v4/users/{user_id}/image", files=files_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def set_default_profile_image(self, user_id):
+    def set_default_profile_image(self, user_id: str):
         """Delete user's profile image
 
         user_id: User GUID
@@ -333,7 +523,7 @@ class Users(Base):
         """
         return self.client.delete(f"/api/v4/users/{user_id}/image")
 
-    def get_default_profile_image(self, user_id):
+    def get_default_profile_image(self, user_id: str):
         """Return user's default (generated) profile image
 
         user_id: User GUID
@@ -343,7 +533,7 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/image/default")
 
-    def get_user_by_username(self, username):
+    def get_user_by_username(self, username: str):
         """Get a user by username
 
         username: Username
@@ -353,7 +543,7 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/username/{username}")
 
-    def reset_password(self, options):
+    def reset_password(self, code: str, new_password: str):
         """Reset password
 
         code: The recovery code
@@ -362,9 +552,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - ResetPassword) <https://api.mattermost.com/#tag/users/operation/ResetPassword>`_
 
         """
-        return self.client.post("""/api/v4/users/password/reset""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"code": code, "new_password": new_password}
+        return self.client.post("""/api/v4/users/password/reset""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_user_mfa(self, user_id, options):
+    def update_user_mfa(self, user_id: str, activate: bool, code: str | None = None):
         """Update a user's MFA
 
         user_id: User GUID
@@ -374,9 +565,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - UpdateUserMfa) <https://api.mattermost.com/#tag/users/operation/UpdateUserMfa>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/mfa", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"activate": activate, "code": code}
+        return self.client.put(f"/api/v4/users/{user_id}/mfa", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def generate_mfa_secret(self, user_id):
+    def generate_mfa_secret(self, user_id: str):
         """Generate MFA secret
 
         user_id: User GUID
@@ -386,7 +578,7 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/mfa/generate")
 
-    def demote_user_to_guest(self, user_id):
+    def demote_user_to_guest(self, user_id: str):
         """Demote a user to a guest
 
         user_id: User GUID
@@ -396,7 +588,7 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/demote")
 
-    def promote_guest_to_user(self, user_id):
+    def promote_guest_to_user(self, user_id: str):
         """Promote a guest to user
 
         user_id: User GUID
@@ -406,7 +598,7 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/promote")
 
-    def convert_user_to_bot(self, user_id):
+    def convert_user_to_bot(self, user_id: str):
         """Convert a user into a bot
 
         user_id: User GUID
@@ -416,7 +608,7 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/convert_to_bot")
 
-    def check_user_mfa(self, options):
+    def check_user_mfa(self, login_id: str):
         """Check MFA
 
         login_id: The email or username used to login
@@ -424,9 +616,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - CheckUserMfa) <https://api.mattermost.com/#tag/users/operation/CheckUserMfa>`_
 
         """
-        return self.client.post("""/api/v4/users/mfa""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"login_id": login_id}
+        return self.client.post("""/api/v4/users/mfa""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_user_password(self, user_id, options):
+    def update_user_password(self, user_id: str, new_password: str, current_password: str | None = None):
         """Update a user's password
 
         user_id: User GUID
@@ -436,9 +629,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - UpdateUserPassword) <https://api.mattermost.com/#tag/users/operation/UpdateUserPassword>`_
 
         """
-        return self.client.put(f"/api/v4/users/{user_id}/password", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"current_password": current_password, "new_password": new_password}
+        return self.client.put(f"/api/v4/users/{user_id}/password", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def send_password_reset_email(self, options):
+    def send_password_reset_email(self, email: str):
         """Send password reset email
 
         email: The email of the user
@@ -446,9 +640,12 @@ class Users(Base):
         `Read in Mattermost API docs (users - SendPasswordResetEmail) <https://api.mattermost.com/#tag/users/operation/SendPasswordResetEmail>`_
 
         """
-        return self.client.post("""/api/v4/users/password/reset/send""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"email": email}
+        return self.client.post(
+            """/api/v4/users/password/reset/send""", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_user_by_email(self, email):
+    def get_user_by_email(self, email: str):
         """Get a user by email
 
         email: User Email
@@ -458,7 +655,7 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/email/{email}")
 
-    def get_sessions(self, user_id):
+    def get_sessions(self, user_id: str):
         """Get user's sessions
 
         user_id: User GUID
@@ -468,7 +665,7 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/sessions")
 
-    def revoke_session(self, user_id, options):
+    def revoke_session(self, user_id: str, session_id: str):
         """Revoke a user session
 
         user_id: User GUID
@@ -477,9 +674,12 @@ class Users(Base):
         `Read in Mattermost API docs (users - RevokeSession) <https://api.mattermost.com/#tag/users/operation/RevokeSession>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/sessions/revoke", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"session_id": session_id}
+        return self.client.post(
+            f"/api/v4/users/{user_id}/sessions/revoke", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def revoke_all_sessions(self, user_id):
+    def revoke_all_sessions(self, user_id: str):
         """Revoke all active sessions for a user
 
         user_id: User GUID
@@ -489,7 +689,12 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/sessions/revoke/all")
 
-    def attach_device_extra_props(self, options):
+    def attach_device_extra_props(
+        self,
+        device_id: str | None = None,
+        deviceNotificationDisabled: str | None = None,
+        mobileVersion: str | None = None,
+    ):
         """Attach mobile device and extra props to the session object
 
         device_id: Mobile device id. For Android prefix the id with ``android:`` and Apple with ``apple:``
@@ -499,9 +704,14 @@ class Users(Base):
         `Read in Mattermost API docs (users - AttachDeviceExtraProps) <https://api.mattermost.com/#tag/users/operation/AttachDeviceExtraProps>`_
 
         """
-        return self.client.put("""/api/v4/users/sessions/device""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "device_id": device_id,
+            "deviceNotificationDisabled": deviceNotificationDisabled,
+            "mobileVersion": mobileVersion,
+        }
+        return self.client.put("""/api/v4/users/sessions/device""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user_audits(self, user_id):
+    def get_user_audits(self, user_id: str):
         """Get user's audits
 
         user_id: User GUID
@@ -511,7 +721,7 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/audits")
 
-    def verify_user_email_without_token(self, user_id):
+    def verify_user_email_without_token(self, user_id: str):
         """Verify user email by ID
 
         user_id: User GUID
@@ -521,7 +731,7 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/email/verify/member")
 
-    def verify_user_email(self, options):
+    def verify_user_email(self, token: str):
         """Verify user email
 
         token: The token given to validate the email
@@ -529,9 +739,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - VerifyUserEmail) <https://api.mattermost.com/#tag/users/operation/VerifyUserEmail>`_
 
         """
-        return self.client.post("""/api/v4/users/email/verify""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"token": token}
+        return self.client.post("""/api/v4/users/email/verify""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def send_verification_email(self, options):
+    def send_verification_email(self, email: str):
         """Send verification email
 
         email: Email of a user
@@ -539,9 +750,18 @@ class Users(Base):
         `Read in Mattermost API docs (users - SendVerificationEmail) <https://api.mattermost.com/#tag/users/operation/SendVerificationEmail>`_
 
         """
-        return self.client.post("""/api/v4/users/email/verify/send""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"email": email}
+        return self.client.post("""/api/v4/users/email/verify/send""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def switch_account_type(self, options):
+    def switch_account_type(
+        self,
+        current_service: str,
+        new_service: str,
+        email: str | None = None,
+        password: str | None = None,
+        mfa_code: str | None = None,
+        ldap_id: str | None = None,
+    ):
         """Switch login method
 
         current_service: The service the user currently uses to login
@@ -554,9 +774,17 @@ class Users(Base):
         `Read in Mattermost API docs (users - SwitchAccountType) <https://api.mattermost.com/#tag/users/operation/SwitchAccountType>`_
 
         """
-        return self.client.post("""/api/v4/users/login/switch""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "current_service": current_service,
+            "new_service": new_service,
+            "email": email,
+            "password": password,
+            "mfa_code": mfa_code,
+            "ldap_id": ldap_id,
+        }
+        return self.client.post("""/api/v4/users/login/switch""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_user_access_token(self, user_id, options):
+    def create_user_access_token(self, user_id: str, description: str):
         """Create a user access token
 
         user_id: User GUID
@@ -565,9 +793,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - CreateUserAccessToken) <https://api.mattermost.com/#tag/users/operation/CreateUserAccessToken>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/tokens", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"description": description}
+        return self.client.post(f"/api/v4/users/{user_id}/tokens", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user_access_tokens_for_user(self, user_id, params=None):
+    def get_user_access_tokens_for_user(self, user_id: str, page: int | None = 0, per_page: int | None = 60):
         """Get user access tokens
 
         user_id: User GUID
@@ -577,9 +806,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetUserAccessTokensForUser) <https://api.mattermost.com/#tag/users/operation/GetUserAccessTokensForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/tokens", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(f"/api/v4/users/{user_id}/tokens", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user_access_tokens(self, params=None):
+    def get_user_access_tokens(self, page: int | None = 0, per_page: int | None = 60):
         """Get user access tokens
 
         page: The page to select.
@@ -588,9 +818,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetUserAccessTokens) <https://api.mattermost.com/#tag/users/operation/GetUserAccessTokens>`_
 
         """
-        return self.client.get("""/api/v4/users/tokens""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/users/tokens""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def revoke_user_access_token(self, options):
+    def revoke_user_access_token(self, token_id: str):
         """Revoke a user access token
 
         token_id: The user access token GUID to revoke
@@ -598,9 +829,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - RevokeUserAccessToken) <https://api.mattermost.com/#tag/users/operation/RevokeUserAccessToken>`_
 
         """
-        return self.client.post("""/api/v4/users/tokens/revoke""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"token_id": token_id}
+        return self.client.post("""/api/v4/users/tokens/revoke""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_user_access_token(self, token_id):
+    def get_user_access_token(self, token_id: str):
         """Get a user access token
 
         token_id: User access token GUID
@@ -610,7 +842,7 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/tokens/{token_id}")
 
-    def disable_user_access_token(self, options):
+    def disable_user_access_token(self, token_id: str):
         """Disable personal access token
 
         token_id: The personal access token GUID to disable
@@ -618,9 +850,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - DisableUserAccessToken) <https://api.mattermost.com/#tag/users/operation/DisableUserAccessToken>`_
 
         """
-        return self.client.post("""/api/v4/users/tokens/disable""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"token_id": token_id}
+        return self.client.post("""/api/v4/users/tokens/disable""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def enable_user_access_token(self, options):
+    def enable_user_access_token(self, token_id: str):
         """Enable personal access token
 
         token_id: The personal access token GUID to enable
@@ -628,9 +861,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - EnableUserAccessToken) <https://api.mattermost.com/#tag/users/operation/EnableUserAccessToken>`_
 
         """
-        return self.client.post("""/api/v4/users/tokens/enable""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"token_id": token_id}
+        return self.client.post("""/api/v4/users/tokens/enable""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def search_user_access_tokens(self, options):
+    def search_user_access_tokens(self, term: str):
         """Search tokens
 
         term: The search term to match against the token id, user id or username.
@@ -638,9 +872,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - SearchUserAccessTokens) <https://api.mattermost.com/#tag/users/operation/SearchUserAccessTokens>`_
 
         """
-        return self.client.post("""/api/v4/users/tokens/search""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"term": term}
+        return self.client.post("""/api/v4/users/tokens/search""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def update_user_auth(self, user_id, options):
+    def update_user_auth(self, user_id: str, options: Any):
         """Update a user's authentication method
 
         user_id: User GUID
@@ -650,7 +885,7 @@ class Users(Base):
         """
         return self.client.put(f"/api/v4/users/{user_id}/auth", options=options)
 
-    def register_terms_of_service_action(self, user_id, options):
+    def register_terms_of_service_action(self, user_id: str, serviceTermsId: str, accepted: str):
         """Records user action when they accept or decline custom terms of service
 
         user_id: User GUID
@@ -660,9 +895,12 @@ class Users(Base):
         `Read in Mattermost API docs (users - RegisterTermsOfServiceAction) <https://api.mattermost.com/#tag/users/operation/RegisterTermsOfServiceAction>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/terms_of_service", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"serviceTermsId": serviceTermsId, "accepted": accepted}
+        return self.client.post(
+            f"/api/v4/users/{user_id}/terms_of_service", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def get_user_terms_of_service(self, user_id):
+    def get_user_terms_of_service(self, user_id: str):
         """Fetches user's latest terms of service action if the latest action was for acceptance.
 
         user_id: User GUID
@@ -679,7 +917,7 @@ class Users(Base):
         """
         return self.client.post("""/api/v4/users/sessions/revoke/all""")
 
-    def publish_user_typing(self, user_id, options=None):
+    def publish_user_typing(self, user_id: str, channel_id: str, parent_id: str | None = None):
         """Publish a user typing websocket event.
 
         user_id: User GUID
@@ -689,9 +927,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - PublishUserTyping) <https://api.mattermost.com/#tag/users/operation/PublishUserTyping>`_
 
         """
-        return self.client.post(f"/api/v4/users/{user_id}/typing", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"channel_id": channel_id, "parent_id": parent_id}
+        return self.client.post(f"/api/v4/users/{user_id}/typing", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_uploads_for_user(self, user_id):
+    def get_uploads_for_user(self, user_id: str):
         """Get uploads for a user
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -701,7 +940,9 @@ class Users(Base):
         """
         return self.client.get(f"/api/v4/users/{user_id}/uploads")
 
-    def get_channel_members_with_team_data_for_user(self, user_id, params=None):
+    def get_channel_members_with_team_data_for_user(
+        self, user_id: str, page: int | None = None, per_page: int | None = 60
+    ):
         """Get all channel members from all teams for a user
 
         user_id: The ID of the user. This can also be "me" which will point to the current user.
@@ -711,9 +952,12 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetChannelMembersWithTeamDataForUser) <https://api.mattermost.com/#tag/users/operation/GetChannelMembersWithTeamDataForUser>`_
 
         """
-        return self.client.get(f"/api/v4/users/{user_id}/channel_members", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get(
+            f"/api/v4/users/{user_id}/channel_members", params=params_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
-    def migrate_auth_to_ldap(self, options=None):
+    def migrate_auth_to_ldap(self, from_: str, match_field: str, force: bool):
         """Migrate user accounts authentication type to LDAP.
 
         from: The current authentication type for the matched users.
@@ -723,9 +967,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - MigrateAuthToLdap) <https://api.mattermost.com/#tag/users/operation/MigrateAuthToLdap>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/ldap""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "match_field": match_field, "force": force}
+        return self.client.post("""/api/v4/users/migrate_auth/ldap""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def migrate_auth_to_saml(self, options=None):
+    def migrate_auth_to_saml(self, from_: str, matches: dict[str, Any], auto: bool):
         """Migrate user accounts authentication type to SAML.
 
         from: The current authentication type for the matched users.
@@ -735,9 +980,10 @@ class Users(Base):
         `Read in Mattermost API docs (users - MigrateAuthToSaml) <https://api.mattermost.com/#tag/users/operation/MigrateAuthToSaml>`_
 
         """
-        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {"from": from_, "matches": matches, "auto": auto}
+        return self.client.post("""/api/v4/users/migrate_auth/saml""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_users_with_invalid_emails(self, params=None):
+    def get_users_with_invalid_emails(self, page: int | None = 0, per_page: int | None = 60):
         """Get users with invalid emails
 
         page: The page to select.
@@ -746,7 +992,8 @@ class Users(Base):
         `Read in Mattermost API docs (users - GetUsersWithInvalidEmails) <https://api.mattermost.com/#tag/users/operation/GetUsersWithInvalidEmails>`_
 
         """
-        return self.client.get("""/api/v4/users/invalid_emails""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {"page": page, "per_page": per_page}
+        return self.client.get("""/api/v4/users/invalid_emails""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
     def reset_password_failed_attempts(self):
         """Reset the failed password attempts for a user
@@ -755,7 +1002,20 @@ class Users(Base):
         """
         return self.client.post(f"/api/v4/users/{user_id}/reset_failed_attempts")
 
-    def convert_bot_to_user(self, bot_user_id, options):
+    def convert_bot_to_user(
+        self,
+        bot_user_id: str,
+        email: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        nickname: str | None = None,
+        locale: str | None = None,
+        position: str | None = None,
+        props: dict[str, Any] | None = None,
+        notify_props: Any | None = None,
+    ):
         """Convert a bot into a user
 
         bot_user_id: Bot user ID
@@ -773,7 +1033,21 @@ class Users(Base):
         `Read in Mattermost API docs (users - ConvertBotToUser) <https://api.mattermost.com/#tag/users/operation/ConvertBotToUser>`_
 
         """
-        return self.client.post(f"/api/v4/bots/{bot_user_id}/convert_to_user", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "email": email,
+            "username": username,
+            "password": password,
+            "first_name": first_name,
+            "last_name": last_name,
+            "nickname": nickname,
+            "locale": locale,
+            "position": position,
+            "props": props,
+            "notify_props": notify_props,
+        }
+        return self.client.post(
+            f"/api/v4/bots/{bot_user_id}/convert_to_user", options=options_71f8b7431cd64fcfa0dabd300d0636d2
+        )
 
     def get_server_limits(self):
         """Gets the server limits for the server

--- a/src/mattermostautodriver/endpoints/webhooks.py
+++ b/src/mattermostautodriver/endpoints/webhooks.py
@@ -1,9 +1,18 @@
 from .base import Base
+from typing import Any
 
 
 class Webhooks(Base):
 
-    def create_incoming_webhook(self, options):
+    def create_incoming_webhook(
+        self,
+        channel_id: str,
+        user_id: str | None = None,
+        display_name: str | None = None,
+        description: str | None = None,
+        username: str | None = None,
+        icon_url: str | None = None,
+    ):
         """Create an incoming webhook
 
         channel_id: The ID of a public channel or private group that receives the webhook payloads.
@@ -16,9 +25,23 @@ class Webhooks(Base):
         `Read in Mattermost API docs (webhooks - CreateIncomingWebhook) <https://api.mattermost.com/#tag/webhooks/operation/CreateIncomingWebhook>`_
 
         """
-        return self.client.post("""/api/v4/hooks/incoming""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "channel_id": channel_id,
+            "user_id": user_id,
+            "display_name": display_name,
+            "description": description,
+            "username": username,
+            "icon_url": icon_url,
+        }
+        return self.client.post("""/api/v4/hooks/incoming""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_incoming_webhooks(self, params=None):
+    def get_incoming_webhooks(
+        self,
+        page: int | None = 0,
+        per_page: int | None = 60,
+        team_id: str | None = None,
+        include_total_count: bool | None = False,
+    ):
         """List incoming webhooks
 
         page: The page to select.
@@ -29,9 +52,15 @@ class Webhooks(Base):
         `Read in Mattermost API docs (webhooks - GetIncomingWebhooks) <https://api.mattermost.com/#tag/webhooks/operation/GetIncomingWebhooks>`_
 
         """
-        return self.client.get("""/api/v4/hooks/incoming""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "team_id": team_id,
+            "include_total_count": include_total_count,
+        }
+        return self.client.get("""/api/v4/hooks/incoming""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_incoming_webhook(self, hook_id):
+    def get_incoming_webhook(self, hook_id: str):
         """Get an incoming webhook
 
         hook_id: Incoming Webhook GUID
@@ -41,7 +70,7 @@ class Webhooks(Base):
         """
         return self.client.get(f"/api/v4/hooks/incoming/{hook_id}")
 
-    def delete_incoming_webhook(self, hook_id):
+    def delete_incoming_webhook(self, hook_id: str):
         """Delete an incoming webhook
 
         hook_id: Incoming webhook GUID
@@ -51,7 +80,16 @@ class Webhooks(Base):
         """
         return self.client.delete(f"/api/v4/hooks/incoming/{hook_id}")
 
-    def update_incoming_webhook(self, hook_id, options):
+    def update_incoming_webhook(
+        self,
+        hook_id: str,
+        id: str,
+        channel_id: str,
+        display_name: str,
+        description: str,
+        username: str | None = None,
+        icon_url: str | None = None,
+    ):
         """Update an incoming webhook
 
         hook_id: Incoming Webhook GUID
@@ -65,9 +103,28 @@ class Webhooks(Base):
         `Read in Mattermost API docs (webhooks - UpdateIncomingWebhook) <https://api.mattermost.com/#tag/webhooks/operation/UpdateIncomingWebhook>`_
 
         """
-        return self.client.put(f"/api/v4/hooks/incoming/{hook_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "channel_id": channel_id,
+            "display_name": display_name,
+            "description": description,
+            "username": username,
+            "icon_url": icon_url,
+        }
+        return self.client.put(f"/api/v4/hooks/incoming/{hook_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def create_outgoing_webhook(self, options):
+    def create_outgoing_webhook(
+        self,
+        team_id: str,
+        display_name: str,
+        trigger_words: list[str],
+        callback_urls: list[str],
+        channel_id: str | None = None,
+        creator_id: str | None = None,
+        description: str | None = None,
+        trigger_when: int | None = None,
+        content_type: str | None = "application/x-www-form-urlencoded",
+    ):
         """Create an outgoing webhook
 
         team_id: The ID of the team that the webhook watchs
@@ -83,9 +140,22 @@ class Webhooks(Base):
         `Read in Mattermost API docs (webhooks - CreateOutgoingWebhook) <https://api.mattermost.com/#tag/webhooks/operation/CreateOutgoingWebhook>`_
 
         """
-        return self.client.post("""/api/v4/hooks/outgoing""", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "team_id": team_id,
+            "channel_id": channel_id,
+            "creator_id": creator_id,
+            "description": description,
+            "display_name": display_name,
+            "trigger_words": trigger_words,
+            "trigger_when": trigger_when,
+            "callback_urls": callback_urls,
+            "content_type": content_type,
+        }
+        return self.client.post("""/api/v4/hooks/outgoing""", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_outgoing_webhooks(self, params=None):
+    def get_outgoing_webhooks(
+        self, page: int | None = 0, per_page: int | None = 60, team_id: str | None = None, channel_id: str | None = None
+    ):
         """List outgoing webhooks
 
         page: The page to select.
@@ -96,9 +166,15 @@ class Webhooks(Base):
         `Read in Mattermost API docs (webhooks - GetOutgoingWebhooks) <https://api.mattermost.com/#tag/webhooks/operation/GetOutgoingWebhooks>`_
 
         """
-        return self.client.get("""/api/v4/hooks/outgoing""", params=params)
+        params_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "page": page,
+            "per_page": per_page,
+            "team_id": team_id,
+            "channel_id": channel_id,
+        }
+        return self.client.get("""/api/v4/hooks/outgoing""", params=params_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def get_outgoing_webhook(self, hook_id):
+    def get_outgoing_webhook(self, hook_id: str):
         """Get an outgoing webhook
 
         hook_id: Outgoing webhook GUID
@@ -108,7 +184,7 @@ class Webhooks(Base):
         """
         return self.client.get(f"/api/v4/hooks/outgoing/{hook_id}")
 
-    def delete_outgoing_webhook(self, hook_id):
+    def delete_outgoing_webhook(self, hook_id: str):
         """Delete an outgoing webhook
 
         hook_id: Outgoing webhook GUID
@@ -118,7 +194,7 @@ class Webhooks(Base):
         """
         return self.client.delete(f"/api/v4/hooks/outgoing/{hook_id}")
 
-    def update_outgoing_webhook(self, hook_id, options):
+    def update_outgoing_webhook(self, hook_id: str, id: str, channel_id: str, display_name: str, description: str):
         """Update an outgoing webhook
 
         hook_id: outgoing Webhook GUID
@@ -130,9 +206,15 @@ class Webhooks(Base):
         `Read in Mattermost API docs (webhooks - UpdateOutgoingWebhook) <https://api.mattermost.com/#tag/webhooks/operation/UpdateOutgoingWebhook>`_
 
         """
-        return self.client.put(f"/api/v4/hooks/outgoing/{hook_id}", options=options)
+        options_71f8b7431cd64fcfa0dabd300d0636d2 = {
+            "id": id,
+            "channel_id": channel_id,
+            "display_name": display_name,
+            "description": description,
+        }
+        return self.client.put(f"/api/v4/hooks/outgoing/{hook_id}", options=options_71f8b7431cd64fcfa0dabd300d0636d2)
 
-    def regen_outgoing_hook_token(self, hook_id):
+    def regen_outgoing_hook_token(self, hook_id: str):
         """Regenerate the token for the outgoing webhook.
 
         hook_id: Outgoing webhook GUID

--- a/src/mattermostautodriver/endpoints/webhooks.py
+++ b/src/mattermostautodriver/endpoints/webhooks.py
@@ -1,5 +1,5 @@
 from .base import Base
-from typing import Any
+from typing import Any, BinaryIO
 
 
 class Webhooks(Base):


### PR DESCRIPTION
This updates the AST generating code to extract types from the OpenAPI schema and use them to type the resulting endpoint files (and includes an update of the endpoint files to the new format). Unfortunately, this also includes a rather significant breaking change in the interface, but given that this new way of doing things is how most API clients work, and the one which gives the - by far - best type- and autocomplete-support in modern editors, I do believe it's worth it. The difference between the existing code, and this new proposal is that instead of the library-user submitting the dictionaries corresponding 1-to-1 with the request options, they now submit the specific parameters, which will then be packaged into dictionaries and assigned to the different request options. Following is a couple of examples to see the difference:

```python
# Old
login({"id": "<MM_ID>", "token": "<MM_TOKEN>"})

# New
login(id="<MM_ID>", token="<MM_TOKEN>")


# Old
update_user("<USER_ID>", {"email": "<USER_EMAIL>", "username": "<USER_NAME>"})

# New
update_user("<USER_ID>", email="<USER_EMAIL>", username="<USER_NAME>")

# Old
create_emoji(files=[image_file], data={"name": "<EMOJI_NAME>"})

# New
create_emoji(image=image_file, emoji={"name": "<EMOJI_NAME>"})
```

I haven't updated the docs yet - I will get that underway once we have determined that this is the way we are moving forward.