### PR TITLE
Fix driver login method

### DIFF
--- a/src/mattermostautodriver/driver.py
+++ b/src/mattermostautodriver/driver.py
@@ -177,12 +177,14 @@ class Driver(BaseDriver):
             self.client.token = self.options["token"]
             result = self.users.get_user("me")
         else:
-            response = self.users.login(
+            response = self.client.make_request(
+                "post",
+                """/api/v4/users/login""",
                 {
                     "login_id": self.options["login_id"],
                     "password": self.options["password"],
                     "token": self.options["mfa_token"],
-                }
+                },
             )
             if response.status_code == 200:
                 self.client.token = response.headers["Token"]


### PR DESCRIPTION
Hello there! :wave: 

Thank you for maintaining this :heart:

In the Driver's login method, we are more interested in the headers and cookies than the JSON body:

https://github.com/embl-bio-it/python-mattermost-autodriver/blob/904b1df198171f70eb2a9326e7e6fc8371b8faaf/src/mattermostautodriver/driver.py#L187-L189

So `make_request` needs to be used directly, it used to be the case here: 

https://github.com/embl-bio-it/python-mattermost-autodriver/blob/e792d52b5c6c7710a288b10848d222b2e8f8ca33/src/mattermostdriver/endpoints/users.py#L7-L8


But I assume this is now generated and cannot be fixed or used anymore for that purpose:

https://github.com/embl-bio-it/python-mattermost-autodriver/blob/904b1df198171f70eb2a9326e7e6fc8371b8faaf/src/mattermostautodriver/endpoints/users.py#L38

Thus this change to call `make_request` in the driver