### PR TITLE
Add close method to driver and client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,11 @@ Usage
     # This method does not exist on the mattermost api AFAIK, I added it for ease of use.
     foo.client.call_webhook('myHookId', options) # Options are optional
 
+    # Finally, logout the user if using login/password authentication.
+    foo.logout()
+
+    # And close the client once done with it.
+    foo.close()
 
 .. inclusion-marker-end-usage
 

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -259,6 +259,9 @@ class Client(BaseClient):
     def call_webhook(self, hook_id, options=None):
         return self.make_request("post", "/hooks/" + hook_id, options=options)
 
+    def close(self):
+        self.client.close()
+
 
 class AsyncClient(BaseClient):
     def __init__(self, options):
@@ -314,3 +317,6 @@ class AsyncClient(BaseClient):
     async def call_webhook(self, hook_id, options=None):
         response = await self.make_request("post", "/hooks/" + hook_id, options=options)
         return response.json()
+
+    async def close(self):
+        await self.client.aclose()

--- a/src/mattermostautodriver/driver.py
+++ b/src/mattermostautodriver/driver.py
@@ -215,6 +215,9 @@ class Driver(BaseDriver):
         self.client.cookies = None
         return result
 
+    def close(self):
+        self.client.close()
+
 
 class AsyncDriver(BaseDriver):
     def __init__(self, options=None, client_cls=AsyncClient, *args, **kwargs):
@@ -307,3 +310,6 @@ class AsyncDriver(BaseDriver):
         self.client.username = ""
         self.client.cookies = None
         return result
+
+    async def close(self):
+        await self.client.close()


### PR DESCRIPTION
With `httpx`, the HTTP transport must be closed, this adds `close` methods to the client and driver as well as documentation to make it obvious.

Spotted the warning with [`PYTHONDEVMODE=1`](https://docs.python.org/3/library/devmode.html):

```
sys:1: ResourceWarning: unclosed <socket.socket fd=3, family=2, type=1, proto=6, laddr=('127.0.0.1', 49060), raddr=('127.0.0.1', 8065)> 
```

The alternative is to dig the properties and call `close` there like `driver.client.client.close()`

References:

- [Usage - Clients - HTTPX](https://www.python-httpx.org/advanced/clients/#usage)
- [Opening and closing clients - Async Support - HTTPX](https://www.python-httpx.org/async/#opening-and-closing-clients)
- [Pool lifespans - Connection Pools - HTTPCore](https://www.encode.io/httpcore/connection-pools/#pool-lifespans)