### PR TITLE
Adapt filter_dict_or_none to keep any non-dict unchanged

### DIFF
--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -132,8 +132,9 @@ class BaseClient:
 
     def _build_request(self, method, options=None, params=None, data=None, files=None):
         def filter_dict_or_none(d):
-            if d is None:
-                return None
+            if not isinstance(d, dict):
+                # this method is only meant to filter dicts, return everything else unchanged
+                return d
 
             filtered_d = {k: v for k, v in d.items() if v is not None}
 


### PR DESCRIPTION
The behavior for d=None is unchanged, but if d is e.g. a list, it will now be returned unchanged rather than raising an AttributeError.