### PR TITLE
Retries

### DIFF
--- a/.github/workflows/run_tests_pull_request.yml
+++ b/.github/workflows/run_tests_pull_request.yml
@@ -1,0 +1,26 @@
+name: Run tests
+
+on: [pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt -r requirements-dev.txt
+        pip install .
+    - name: Run pytest
+      run: pytest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,9 @@ Code
   ``PUT``, ``DELETE``, ``HEAD``) to avoid e.g. duplicating posted messages.
   Behavior is controlled by the new driver options ``max_retries`` (default 3,
   0 disables retrying) and ``retry_max_sleep`` (default 30 seconds, caps a
-  single wait between retries). Requests uploading files are never retried
-  automatically.
+  single wait between retries). Requests carrying files or a streaming
+  request body are never retried automatically, as their content is consumed
+  when the request is first sent.
 - **Backwards incompatible:** HTTP 429 responses now raise the new
   ``TooManyRequests`` exception, which exposes the server provided wait time
   as its ``retry_after`` attribute. Previously a 429 raised

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,32 @@ Unreleased
 Code
 ''''
 
+- Automatically retry requests that fail due to rate limiting or transient
+  errors. HTTP 429 responses are retried for all requests, honoring the
+  ``Retry-After`` / ``X-RateLimit-Reset`` headers. Connection errors and
+  502/503/504 responses are only retried for idempotent requests (``GET``,
+  ``PUT``, ``DELETE``, ``HEAD``) to avoid e.g. duplicating posted messages.
+  Behavior is controlled by the new driver options ``max_retries`` (default 3,
+  0 disables retrying) and ``retry_max_sleep`` (default 30 seconds, caps a
+  single wait between retries). Requests uploading files are never retried
+  automatically.
+- **Backwards incompatible:** HTTP 429 responses now raise the new
+  ``TooManyRequests`` exception, which exposes the server provided wait time
+  as its ``retry_after`` attribute. Previously a 429 raised
+  ``UnknownMattermostError`` or ``InvalidMattermostError`` depending on the
+  response body.
 
 Documentation
 '''''''''''''
 
+- Document the automatic retry behavior and the ``TooManyRequests`` exception.
 
 Maintenance
 '''''''''''
 
 - Fix websocket heartbeat task leak on reconnect (@lizakoch)
+- Add a pytest based test suite for the HTTP client and run it on pull
+  requests in CI.
 
 11.8.1
 """"""

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Code
 
 - Automatically retry requests that fail due to rate limiting or transient
   errors. HTTP 429 responses are retried for all requests, honoring the
-  ``Retry-After`` / ``X-RateLimit-Reset`` headers. Connection errors and
+  ``Retry-After`` / ``X-RateLimit-Reset`` headers in their delay-seconds,
+  HTTP-date and unix timestamp forms. Connection errors and
   502/503/504 responses are only retried for idempotent requests (``GET``,
   ``PUT``, ``DELETE``, ``HEAD``) to avoid e.g. duplicating posted messages.
   Behavior is controlled by the new driver options ``max_retries`` (default 3,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,25 @@ Usage
 
 .. include:: auth.rst
 
+Retries
+'''''''
+
+Requests that fail due to server side rate limiting (HTTP 429) are retried
+automatically, honoring the ``Retry-After`` / ``X-RateLimit-Reset`` response
+headers. Connection errors and 502/503/504 responses are also retried, but
+only for idempotent requests (``GET``, ``PUT``, ``DELETE`` and ``HEAD``),
+since a ``POST`` may already have been processed by the server. Requests
+uploading files are never retried automatically.
+
+Two driver options control this behavior:
+
+- ``max_retries`` (default ``3``) - maximum number of automatic retries per
+  request. Set to ``0`` to disable retrying entirely.
+- ``retry_max_sleep`` (default ``30``) - upper bound in seconds for a single
+  wait between retries. If the server requests a longer wait, the request
+  fails immediately with ``TooManyRequests`` and the requested wait time is
+  available in its ``retry_after`` attribute.
+
 Classes
 '''''''
 
@@ -72,6 +91,8 @@ Exceptions that api requests can throw
 .. autoclass:: ResourceNotFound
 
 .. autoclass:: ContentTooLarge
+
+.. autoclass:: TooManyRequests
 
 .. autoclass:: FeatureDisabled
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,55 @@ backoff instead. The same parsed wait is exposed to callers as the
 ``retry_after`` attribute of ``TooManyRequests``, always as non-negative
 seconds from now.
 
+The full mapping of failure modes to exceptions and retry behavior:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 34 44
+
+   * - Failure
+     - Exception
+     - Retry behavior
+   * - HTTP 400
+     - ``InvalidOrMissingParameters``
+     - Not retried
+   * - HTTP 401
+     - ``NoAccessTokenProvided``
+     - Not retried
+   * - HTTP 403
+     - ``NotEnoughPermissions``
+     - Not retried
+   * - HTTP 404
+     - ``ResourceNotFound``
+     - Not retried
+   * - HTTP 405
+     - ``MethodNotAllowed``
+     - Not retried
+   * - HTTP 413
+     - ``ContentTooLarge``
+     - Not retried
+   * - HTTP 429
+     - ``TooManyRequests``
+     - Retried for all methods, waiting as requested by the server
+   * - HTTP 501
+     - ``FeatureDisabled``
+     - Not retried
+   * - HTTP 502 / 503 / 504
+     - ``UnknownMattermostError``
+     - Retried with exponential backoff, idempotent methods only
+   * - Other HTTP error codes
+     - ``UnknownMattermostError``
+     - Not retried
+   * - Connection errors and timeouts
+     - ``httpx.TransportError`` (raised by httpx)
+     - Retried with exponential backoff, idempotent methods only
+
+The listed exception is what a request raises once it fails for good - either
+immediately for non-retried failures, or after retries are exhausted. Error
+responses other than 429 whose body does not follow the standard Mattermost
+JSON error schema raise ``InvalidMattermostError`` instead of the exception
+listed above.
+
 Two driver options control this behavior:
 
 - ``max_retries`` (default ``3``) - maximum number of automatic retries per
@@ -102,6 +151,8 @@ Exceptions that api requests can throw
 .. autoclass:: NotEnoughPermissions
 
 .. autoclass:: ResourceNotFound
+
+.. autoclass:: MethodNotAllowed
 
 .. autoclass:: ContentTooLarge
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,8 @@ automatically, honoring the ``Retry-After`` / ``X-RateLimit-Reset`` response
 headers. Connection errors and 502/503/504 responses are also retried, but
 only for idempotent requests (``GET``, ``PUT``, ``DELETE`` and ``HEAD``),
 since a ``POST`` may already have been processed by the server. Requests
-uploading files are never retried automatically.
+carrying files or a streaming request body are never retried automatically,
+as their content is consumed when the request is first sent.
 
 Two driver options control this behavior:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,6 +118,13 @@ Two driver options control this behavior:
   fails immediately with ``TooManyRequests`` and the requested wait time is
   available in its ``retry_after`` attribute.
 
+Together these bound the total time a single call may spend waiting between
+attempts at ``max_retries * retry_max_sleep`` - 90 seconds with the defaults,
+reached only if the server repeatedly requests near-maximum waits. When no
+usable wait is provided and exponential backoff applies, the default total is
+3.5-7 seconds instead. Set ``max_retries`` to ``0`` if failing fast matters
+more than resilience.
+
 Classes
 '''''''
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,12 +41,24 @@ Retries
 '''''''
 
 Requests that fail due to server side rate limiting (HTTP 429) are retried
-automatically, honoring the ``Retry-After`` / ``X-RateLimit-Reset`` response
-headers. Connection errors and 502/503/504 responses are also retried, but
-only for idempotent requests (``GET``, ``PUT``, ``DELETE`` and ``HEAD``),
-since a ``POST`` may already have been processed by the server. Requests
-carrying files or a streaming request body are never retried automatically,
-as their content is consumed when the request is first sent.
+automatically, honoring the wait requested by the server. Connection errors
+and 502/503/504 responses are also retried, but only for idempotent requests
+(``GET``, ``PUT``, ``DELETE`` and ``HEAD``), since a ``POST`` may already
+have been processed by the server. Requests carrying files or a streaming
+request body are never retried automatically, as their content is consumed
+when the request is first sent.
+
+The wait is read from the ``Retry-After`` header if present, falling back to
+``X-RateLimit-Reset`` otherwise. ``Retry-After`` takes precedence because it
+is the header standardized by the HTTP specification (RFC 9110), whereas the
+``X-RateLimit-*`` headers - which Mattermost also sends - are an unstandardized
+convention. Values are accepted in the forms found in the wild: a delay in
+seconds (``120``), an HTTP-date (``Wed, 21 Oct 2026 07:28:00 GMT``), and an
+absolute unix timestamp (``1794000000``). An unparseable header is skipped in
+favor of the next one; if no usable value remains, retries use exponential
+backoff instead. The same parsed wait is exposed to callers as the
+``retry_after`` attribute of ``TooManyRequests``, always as non-negative
+seconds from now.
 
 Two driver options control this behavior:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
 [tool.black]
 line-length = 120
 target-version = ['py310']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8
+pytest-asyncio>=0.24

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -224,24 +224,38 @@ class BaseClient:
         return None
 
     @staticmethod
+    def _parse_error_fields(response):
+        """Extract the fields of a standard Mattermost JSON error body.
+
+        Returns (message, error_id, request_id, is_oauth_error). Raises
+        ValueError when the body does not follow the standard error schema,
+        with the original parsing error as its cause.
+        """
+        try:
+            data = response.json()
+            return (
+                data["message"],
+                data["id"],
+                data["request_id"],
+                data.get("is_oauth", False),  # is_oauth is not always present
+            )
+        except (ValueError, KeyError, TypeError) as err:
+            raise ValueError("Response body does not follow the Mattermost error schema") from err
+
+    @staticmethod
     def _make_rate_limit_error(response):
         # Mattermost's rate limiter replies with a plain text body ("limit exceeded")
         # rather than the standard JSON error, so both the wait time and the error
         # details are parsed on a best effort basis.
         retry_after = BaseClient._parse_retry_after(response)
 
-        message = response.text
-        error_id = None
-        request_id = None
-        is_oauth_error = False
         try:
-            data = response.json()
-            message = data["message"]
-            error_id = data["id"]
-            request_id = data["request_id"]
-            is_oauth_error = data.get("is_oauth", False)
-        except (ValueError, KeyError, TypeError):
-            pass
+            message, error_id, request_id, is_oauth_error = BaseClient._parse_error_fields(response)
+        except ValueError:
+            message = response.text
+            error_id = None
+            request_id = None
+            is_oauth_error = False
 
         return TooManyRequests(message, retry_after, error_id, request_id, is_oauth_error)
 
@@ -299,15 +313,8 @@ class BaseClient:
             if e.response.status_code == 429:
                 raise BaseClient._make_rate_limit_error(e.response) from None
             try:
-                data = e.response.json()
-
-                # TODO: Validate type of incoming data
-                message = data["message"]
-                error_id = data["id"]
-                request_id = data["request_id"]
-                is_oauth_error = data.get("is_oauth", False)  # is_oauth is not always present
-
-            except (ValueError, KeyError) as val_err:
+                message, error_id, request_id, is_oauth_error = BaseClient._parse_error_fields(e.response)
+            except ValueError as val_err:
                 raise InvalidMattermostError(e.response.text, e.response.status_code) from val_err
             log.error(message)
 

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -210,32 +210,48 @@ class BaseClient:
 
         return TooManyRequests(message, retry_after, error_id, request_id, is_oauth_error)
 
-    def _retry_delay(self, method, attempt, response=None, exception=None):
+    @staticmethod
+    def _body_is_replayable(data, files):
+        """Whether the request body can safely be sent a second time.
+
+        Files and non-dict ``data`` bodies (e.g. a file object or generator)
+        are consumed when the request is first sent, so resending them would
+        transmit an empty body.
+        """
+        return files is None and (data is None or isinstance(data, dict))
+
+    def _retry_delay(self, method, attempt, data=None, files=None, response=None):
         """Seconds to wait before retrying the request, or None if it must not be retried.
 
         A 429 is retried for any method since the server rejected the request
-        outright. Connection errors and 502/503/504 responses are only retried
-        for idempotent methods, as a POST may already have been processed.
+        outright. Connection errors (``response is None``) and 502/503/504
+        responses are only retried for idempotent methods, as a POST may
+        already have been processed. Requests whose body is not replayable
+        are never retried.
         """
+        if not self._body_is_replayable(data, files):
+            return None
+
         if attempt >= self._max_retries:
             return None
 
         method = method.lower()
         backoff = min(0.5 * 2**attempt * (1 + random.random()), self._retry_max_sleep)
 
-        if response is not None:
-            if response.status_code == 429:
-                retry_after = self._parse_retry_after(response)
-                if retry_after is None:
-                    return backoff
-                if retry_after > self._retry_max_sleep:
-                    return None
-                return retry_after
-            if response.status_code in self._RETRY_STATUS_CODES and method in self._IDEMPOTENT_METHODS:
+        if response is None:
+            if method in self._IDEMPOTENT_METHODS:
                 return backoff
             return None
 
-        if exception is not None and method in self._IDEMPOTENT_METHODS:
+        if response.status_code == 429:
+            retry_after = self._parse_retry_after(response)
+            if retry_after is None:
+                return backoff
+            if retry_after > self._retry_max_sleep:
+                return None
+            return max(0.0, retry_after)
+
+        if response.status_code in self._RETRY_STATUS_CODES and method in self._IDEMPOTENT_METHODS:
             return backoff
 
         return None
@@ -314,20 +330,17 @@ class Client(BaseClient):
             )
         request, url, request_params = self._build_request(method, options, params, data, files)
 
-        # File objects are consumed when the request is sent and cannot be
-        # replayed, so requests carrying files are never retried automatically
-        allow_retry = files is None
         attempt = 0
         while True:
             try:
                 response = request(url + endpoint, **request_params)
             except httpx.TransportError as e:
-                delay = self._retry_delay(method, attempt, exception=e) if allow_retry else None
+                delay = self._retry_delay(method, attempt, data=data, files=files)
                 if delay is None:
                     raise
                 log.warning("Received %r - retrying in %.1f seconds", e, delay)
             else:
-                delay = self._retry_delay(method, attempt, response=response) if allow_retry else None
+                delay = self._retry_delay(method, attempt, data=data, files=files, response=response)
                 if delay is None:
                     self._check_response(response)
                     return response
@@ -400,20 +413,17 @@ class AsyncClient(BaseClient):
             )
         request, url, request_params = self._build_request(method, options, params, data, files)
 
-        # File objects are consumed when the request is sent and cannot be
-        # replayed, so requests carrying files are never retried automatically
-        allow_retry = files is None
         attempt = 0
         while True:
             try:
                 response = await request(url + endpoint, **request_params)
             except httpx.TransportError as e:
-                delay = self._retry_delay(method, attempt, exception=e) if allow_retry else None
+                delay = self._retry_delay(method, attempt, data=data, files=files)
                 if delay is None:
                     raise
                 log.warning("Received %r - retrying in %.1f seconds", e, delay)
             else:
-                delay = self._retry_delay(method, attempt, response=response) if allow_retry else None
+                delay = self._retry_delay(method, attempt, data=data, files=files, response=response)
                 if delay is None:
                     self._check_response(response)
                     return response

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -7,6 +7,8 @@ import asyncio
 import logging
 import random
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 import httpx
 
@@ -177,15 +179,48 @@ class BaseClient:
 
         return self._get_request_method(method, self.client), self.url, request_params
 
+    # Numeric header values above this are far too large to be a wait time
+    # in seconds and are interpreted as an absolute unix timestamp instead
+    _EPOCH_THRESHOLD = 1e8
+
+    @staticmethod
+    def _parse_wait_time(value):
+        """Parse a rate limit header value into seconds to wait from now.
+
+        Handles the conventions used in the wild:
+
+        - delay in seconds ("120") - RFC 7231 ``Retry-After`` and Mattermost's
+          relative ``X-RateLimit-Reset``
+        - HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT") - the alternative
+          ``Retry-After`` form, sent by some proxies and CDNs
+        - absolute unix timestamp ("1794000000") - the ``X-RateLimit-Reset``
+          convention of many API gateways
+
+        Returns non-negative seconds, or None if the value is unparseable.
+        """
+        try:
+            seconds = float(value)
+        except ValueError:
+            try:
+                when = parsedate_to_datetime(value)
+            except (TypeError, ValueError):
+                return None
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=timezone.utc)
+            seconds = (when - datetime.now(timezone.utc)).total_seconds()
+        else:
+            if seconds > BaseClient._EPOCH_THRESHOLD:
+                seconds -= time.time()
+        return max(0.0, seconds)
+
     @staticmethod
     def _parse_retry_after(response):
         for header in ("Retry-After", "X-RateLimit-Reset"):
             value = response.headers.get(header)
             if value is not None:
-                try:
-                    return float(value)
-                except ValueError:
-                    continue
+                wait = BaseClient._parse_wait_time(value)
+                if wait is not None:
+                    return wait
         return None
 
     @staticmethod
@@ -249,7 +284,7 @@ class BaseClient:
                 return backoff
             if retry_after > self._retry_max_sleep:
                 return None
-            return max(0.0, retry_after)
+            return retry_after
 
         if response.status_code in self._RETRY_STATUS_CODES and method in self._IDEMPOTENT_METHODS:
             return backoff

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -227,6 +227,7 @@ class Client(BaseClient):
             http2=options.get("http2", False),
             proxy=self._proxy,
             verify=options.get("verify", True),
+            transport=options.get("transport"),
         )
 
     def make_request(self, method, endpoint, options=None, params=None, data=None, files=None, basepath=None):
@@ -288,6 +289,7 @@ class AsyncClient(BaseClient):
             http2=options.get("http2", False),
             proxy=self._proxy,
             verify=options.get("verify", True),
+            transport=options.get("transport"),
         )
 
     async def __aenter__(self):

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -15,6 +15,7 @@ from .exceptions import (
     MethodNotAllowed,
     ContentTooLarge,
     FeatureDisabled,
+    TooManyRequests,
     UnknownMattermostError,
 )
 
@@ -167,10 +168,42 @@ class BaseClient:
         return self._get_request_method(method, self.client), self.url, request_params
 
     @staticmethod
+    def _make_rate_limit_error(response):
+        # Mattermost's rate limiter replies with a plain text body ("limit exceeded")
+        # rather than the standard JSON error, so both the wait time and the error
+        # details are parsed on a best effort basis.
+        retry_after = None
+        for header in ("Retry-After", "X-RateLimit-Reset"):
+            value = response.headers.get(header)
+            if value is not None:
+                try:
+                    retry_after = float(value)
+                except ValueError:
+                    continue
+                break
+
+        message = response.text
+        error_id = None
+        request_id = None
+        is_oauth_error = False
+        try:
+            data = response.json()
+            message = data["message"]
+            error_id = data["id"]
+            request_id = data["request_id"]
+            is_oauth_error = data.get("is_oauth", False)
+        except (ValueError, KeyError, TypeError):
+            pass
+
+        return TooManyRequests(message, retry_after, error_id, request_id, is_oauth_error)
+
+    @staticmethod
     def _check_response(response):
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                raise BaseClient._make_rate_limit_error(e.response) from None
             try:
                 data = e.response.json()
 

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -4,6 +4,9 @@ and actually makes the requests to the mattermost server
 """
 
 import logging
+import random
+import time
+
 import httpx
 
 from .exceptions import (
@@ -24,6 +27,9 @@ log.setLevel(logging.INFO)
 
 
 class BaseClient:
+    _RETRY_STATUS_CODES = (502, 503, 504)
+    _IDEMPOTENT_METHODS = ("get", "put", "delete", "head")
+
     def __init__(self, options):
         self._url = self._make_url(options["scheme"], options["url"], options["port"])
         self._scheme = options["scheme"]
@@ -40,6 +46,9 @@ class BaseClient:
         self._proxy = None
         if options["proxy"]:
             self._proxy = {"all://": options["proxy"]}
+
+        self._max_retries = options.get("max_retries", 3)
+        self._retry_max_sleep = options.get("retry_max_sleep", 30)
 
     @staticmethod
     def _make_url(scheme, url, port):
@@ -168,19 +177,22 @@ class BaseClient:
         return self._get_request_method(method, self.client), self.url, request_params
 
     @staticmethod
-    def _make_rate_limit_error(response):
-        # Mattermost's rate limiter replies with a plain text body ("limit exceeded")
-        # rather than the standard JSON error, so both the wait time and the error
-        # details are parsed on a best effort basis.
-        retry_after = None
+    def _parse_retry_after(response):
         for header in ("Retry-After", "X-RateLimit-Reset"):
             value = response.headers.get(header)
             if value is not None:
                 try:
-                    retry_after = float(value)
+                    return float(value)
                 except ValueError:
                     continue
-                break
+        return None
+
+    @staticmethod
+    def _make_rate_limit_error(response):
+        # Mattermost's rate limiter replies with a plain text body ("limit exceeded")
+        # rather than the standard JSON error, so both the wait time and the error
+        # details are parsed on a best effort basis.
+        retry_after = BaseClient._parse_retry_after(response)
 
         message = response.text
         error_id = None
@@ -196,6 +208,36 @@ class BaseClient:
             pass
 
         return TooManyRequests(message, retry_after, error_id, request_id, is_oauth_error)
+
+    def _retry_delay(self, method, attempt, response=None, exception=None):
+        """Seconds to wait before retrying the request, or None if it must not be retried.
+
+        A 429 is retried for any method since the server rejected the request
+        outright. Connection errors and 502/503/504 responses are only retried
+        for idempotent methods, as a POST may already have been processed.
+        """
+        if attempt >= self._max_retries:
+            return None
+
+        method = method.lower()
+        backoff = min(0.5 * 2**attempt * (1 + random.random()), self._retry_max_sleep)
+
+        if response is not None:
+            if response.status_code == 429:
+                retry_after = self._parse_retry_after(response)
+                if retry_after is None:
+                    return backoff
+                if retry_after > self._retry_max_sleep:
+                    return None
+                return retry_after
+            if response.status_code in self._RETRY_STATUS_CODES and method in self._IDEMPOTENT_METHODS:
+                return backoff
+            return None
+
+        if exception is not None and method in self._IDEMPOTENT_METHODS:
+            return backoff
+
+        return None
 
     @staticmethod
     def _check_response(response):
@@ -270,10 +312,27 @@ class Client(BaseClient):
                 "Please remove it from your code."
             )
         request, url, request_params = self._build_request(method, options, params, data, files)
-        response = request(url + endpoint, **request_params)
 
-        self._check_response(response)
-        return response
+        # File objects are consumed when the request is sent and cannot be
+        # replayed, so requests carrying files are never retried automatically
+        allow_retry = files is None
+        attempt = 0
+        while True:
+            try:
+                response = request(url + endpoint, **request_params)
+            except httpx.TransportError as e:
+                delay = self._retry_delay(method, attempt, exception=e) if allow_retry else None
+                if delay is None:
+                    raise
+                log.warning("Received %r - retrying in %.1f seconds", e, delay)
+            else:
+                delay = self._retry_delay(method, attempt, response=response) if allow_retry else None
+                if delay is None:
+                    self._check_response(response)
+                    return response
+                log.warning("Received status %d - retrying in %.1f seconds", response.status_code, delay)
+            time.sleep(delay)
+            attempt += 1
 
     def __enter__(self):
         self.client.__enter__()

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -3,6 +3,7 @@ Client for the driver, which holds information about the logged in user
 and actually makes the requests to the mattermost server
 """
 
+import asyncio
 import logging
 import random
 import time
@@ -398,10 +399,27 @@ class AsyncClient(BaseClient):
                 "Please remove it from your code."
             )
         request, url, request_params = self._build_request(method, options, params, data, files)
-        response = await request(url + endpoint, **request_params)
 
-        self._check_response(response)
-        return response
+        # File objects are consumed when the request is sent and cannot be
+        # replayed, so requests carrying files are never retried automatically
+        allow_retry = files is None
+        attempt = 0
+        while True:
+            try:
+                response = await request(url + endpoint, **request_params)
+            except httpx.TransportError as e:
+                delay = self._retry_delay(method, attempt, exception=e) if allow_retry else None
+                if delay is None:
+                    raise
+                log.warning("Received %r - retrying in %.1f seconds", e, delay)
+            else:
+                delay = self._retry_delay(method, attempt, response=response) if allow_retry else None
+                if delay is None:
+                    self._check_response(response)
+                    return response
+                log.warning("Received status %d - retrying in %.1f seconds", response.status_code, delay)
+            await asyncio.sleep(delay)
+            attempt += 1
 
     async def get(self, endpoint, options=None, params=None):
         response = await self.make_request("get", endpoint, options=options, params=params)

--- a/src/mattermostautodriver/client.py
+++ b/src/mattermostautodriver/client.py
@@ -377,11 +377,18 @@ class Client(BaseClient):
             try:
                 response = request(url + endpoint, **request_params)
             except httpx.TransportError as e:
+                # No response was received at all: connection failures,
+                # timeouts and protocol errors. Retried for idempotent
+                # methods only, with exponential backoff.
                 delay = self._retry_delay(method, attempt, data=data, files=files)
                 if delay is None:
                     raise
                 log.warning("Received %r - retrying in %.1f seconds", e, delay)
             else:
+                # A response was received: _retry_delay decides based on its
+                # status code (429 for all methods, 502/503/504 for idempotent
+                # methods) and takes the wait for a 429 from its
+                # Retry-After / X-RateLimit-Reset headers.
                 delay = self._retry_delay(method, attempt, data=data, files=files, response=response)
                 if delay is None:
                     self._check_response(response)
@@ -460,11 +467,18 @@ class AsyncClient(BaseClient):
             try:
                 response = await request(url + endpoint, **request_params)
             except httpx.TransportError as e:
+                # No response was received at all: connection failures,
+                # timeouts and protocol errors. Retried for idempotent
+                # methods only, with exponential backoff.
                 delay = self._retry_delay(method, attempt, data=data, files=files)
                 if delay is None:
                     raise
                 log.warning("Received %r - retrying in %.1f seconds", e, delay)
             else:
+                # A response was received: _retry_delay decides based on its
+                # status code (429 for all methods, 502/503/504 for idempotent
+                # methods) and takes the wait for a 429 from its
+                # Retry-After / X-RateLimit-Reset headers.
                 delay = self._retry_delay(method, attempt, data=data, files=files, response=response)
                 if delay is None:
                     self._check_response(response)

--- a/src/mattermostautodriver/driver/base.py
+++ b/src/mattermostautodriver/driver/base.py
@@ -31,6 +31,8 @@ class BaseDriver:
         "debug": False,
         "http2": False,
         "proxy": None,
+        "max_retries": 3,
+        "retry_max_sleep": 30,
     }
     """
     Required options
@@ -52,6 +54,11 @@ class BaseDriver:
         - mfa_token (None)
         - auth (None)
         - debug (False)
+        - max_retries (3) - number of automatic retries for rate limited or
+          transiently failed requests. 0 disables retrying.
+        - retry_max_sleep (30) - upper bound in seconds for a single wait
+          between retries. If the server requests a longer wait the request
+          fails immediately with ``TooManyRequests``.
     """
 
     def __init__(self, options=None, client_cls=Client, *args, **kwargs):

--- a/src/mattermostautodriver/exceptions.py
+++ b/src/mattermostautodriver/exceptions.py
@@ -133,6 +133,35 @@ class ContentTooLarge(MattermostError):
         )
 
 
+class TooManyRequests(MattermostError):
+    """
+    Raised when the server returns a
+    429 Too Many Requests
+
+    Mattermost's rate limiter responds with a plain text body rather than
+    the standard JSON error, so ``error_id`` and ``request_id`` may be None.
+    ``retry_after`` holds the server-provided wait time in seconds, taken
+    from the ``Retry-After`` or ``X-RateLimit-Reset`` header if present.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        retry_after: float | None,
+        error_id: str | None = None,
+        request_id: str | None = None,
+        is_oauth_error: bool = False,
+    ):
+        super().__init__(
+            message=message,
+            status_code=429,
+            error_id=error_id,
+            request_id=request_id,
+            is_oauth_error=is_oauth_error,
+        )
+        self.retry_after: float | None = retry_after
+
+
 class FeatureDisabled(MattermostError):
     """
     Raised when mattermost returns a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+import httpx
+import pytest
+
+from mattermostautodriver.client import AsyncClient, Client
+
+_BASE_OPTIONS = {
+    "scheme": "http",
+    "url": "localhost",
+    "port": 8065,
+    "auth": None,
+    "debug": False,
+    "proxy": None,
+    "request_timeout": None,
+    "max_retries": 0,  # retry tests opt in explicitly
+}
+
+
+def _client_options(handler, extra_options):
+    options = {**_BASE_OPTIONS, "transport": httpx.MockTransport(handler)}
+    options.update(extra_options)
+    return options
+
+
+def make_client(handler, **extra_options):
+    return Client(_client_options(handler, extra_options))
+
+
+def make_async_client(handler, **extra_options):
+    return AsyncClient(_client_options(handler, extra_options))
+
+
+def error_response(status, message="something failed", error_id="api.some.error", request_id="req1234"):
+    return httpx.Response(status, json={"message": message, "id": error_id, "request_id": request_id})
+
+
+def rate_limit_response(headers=None):
+    # Mattermost replies to rate limited requests with a plain text body,
+    # see server/channels/app/ratelimit.go
+    return httpx.Response(429, text="limit exceeded", headers=headers)
+
+
+def sequence_handler(responses):
+    """Handler returning (or raising) each item in turn, repeating the last one."""
+    calls = []
+
+    def handler(request):
+        item = responses[min(len(calls), len(responses) - 1)]
+        calls.append(request)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    return handler, calls
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    """Record retry sleeps from either client instead of actually sleeping."""
+    slept = []
+
+    async def fake_async_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr("mattermostautodriver.client.time.sleep", slept.append)
+    monkeypatch.setattr("mattermostautodriver.client.asyncio.sleep", fake_async_sleep)
+    return slept

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,37 +1,8 @@
 import httpx
 import pytest
 
-from mattermostautodriver.client import AsyncClient
+from conftest import error_response, make_async_client, rate_limit_response, sequence_handler
 from mattermostautodriver.exceptions import TooManyRequests, UnknownMattermostError
-
-from .test_client import error_response, rate_limit_response, sequence_handler
-
-
-def make_async_client(handler, **extra_options):
-    options = {
-        "scheme": "http",
-        "url": "localhost",
-        "port": 8065,
-        "auth": None,
-        "debug": False,
-        "proxy": None,
-        "request_timeout": None,
-        "max_retries": 0,  # retry tests opt in explicitly
-        "transport": httpx.MockTransport(handler),
-    }
-    options.update(extra_options)
-    return AsyncClient(options)
-
-
-@pytest.fixture
-def sleeps(monkeypatch):
-    slept = []
-
-    async def fake_sleep(seconds):
-        slept.append(seconds)
-
-    monkeypatch.setattr("mattermostautodriver.client.asyncio.sleep", fake_sleep)
-    return slept
 
 
 async def test_successful_json_response_is_returned():

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -30,7 +30,9 @@ async def test_429_is_retried_and_honors_retry_after(sleeps):
 
 
 async def test_429_raises_after_retries_are_exhausted(sleeps):
+    # Without an ok response in `sequence_handler`, this test will repeat "Retry-After 0 seconds" for all requests, exhausting the client `max_retries`.
     handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"})])
+
     client = make_async_client(handler, max_retries=3)
 
     with pytest.raises(TooManyRequests):

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,104 @@
+import httpx
+import pytest
+
+from mattermostautodriver.client import AsyncClient
+from mattermostautodriver.exceptions import TooManyRequests, UnknownMattermostError
+
+from .test_client import error_response, rate_limit_response, sequence_handler
+
+
+def make_async_client(handler, **extra_options):
+    options = {
+        "scheme": "http",
+        "url": "localhost",
+        "port": 8065,
+        "auth": None,
+        "debug": False,
+        "proxy": None,
+        "request_timeout": None,
+        "max_retries": 0,  # retry tests opt in explicitly
+        "transport": httpx.MockTransport(handler),
+    }
+    options.update(extra_options)
+    return AsyncClient(options)
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    slept = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr("mattermostautodriver.client.asyncio.sleep", fake_sleep)
+    return slept
+
+
+async def test_successful_json_response_is_returned():
+    client = make_async_client(lambda request: httpx.Response(200, json={"id": "me"}))
+
+    assert await client.get("/users/me") == {"id": "me"}
+
+
+async def test_429_raises_too_many_requests():
+    client = make_async_client(lambda request: rate_limit_response({"Retry-After": "7"}))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        await client.get("/users/me")
+
+    assert excinfo.value.retry_after == 7.0
+
+
+async def test_429_is_retried_and_honors_retry_after(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "2"}), httpx.Response(200, json={"ok": 1})])
+    client = make_async_client(handler, max_retries=3)
+
+    assert await client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+    assert sleeps == [2.0]
+
+
+async def test_429_raises_after_retries_are_exhausted(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"})])
+    client = make_async_client(handler, max_retries=3)
+
+    with pytest.raises(TooManyRequests):
+        await client.get("/users/me")
+
+    assert len(calls) == 4  # initial request + 3 retries
+
+
+async def test_get_is_retried_on_503(sleeps):
+    handler, calls = sequence_handler([error_response(503), httpx.Response(200, json={"ok": 1})])
+    client = make_async_client(handler, max_retries=3)
+
+    assert await client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+
+
+async def test_post_is_not_retried_on_503(sleeps):
+    handler, calls = sequence_handler([error_response(503)])
+    client = make_async_client(handler, max_retries=3)
+
+    with pytest.raises(UnknownMattermostError):
+        await client.post("/posts", options={"message": "hi"})
+
+    assert len(calls) == 1
+
+
+async def test_get_is_retried_on_connection_error(sleeps):
+    handler, calls = sequence_handler([httpx.ConnectError("connection refused"), httpx.Response(200, json={"ok": 1})])
+    client = make_async_client(handler, max_retries=3)
+
+    assert await client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+
+
+async def test_post_is_not_retried_on_connection_error(sleeps):
+    handler, calls = sequence_handler([httpx.ConnectError("connection refused")])
+    client = make_async_client(handler, max_retries=3)
+
+    with pytest.raises(httpx.ConnectError):
+        await client.post("/posts", options={"message": "hi"})
+
+    assert len(calls) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ from mattermostautodriver.exceptions import (
     NoAccessTokenProvided,
     NotEnoughPermissions,
     ResourceNotFound,
+    TooManyRequests,
     UnknownMattermostError,
 )
 
@@ -76,6 +77,60 @@ def test_successful_json_response_is_returned():
     client = make_client(lambda request: httpx.Response(200, json={"id": "me"}))
 
     assert client.get("/users/me") == {"id": "me"}
+
+
+def rate_limit_response(headers=None):
+    # Mattermost replies to rate limited requests with a plain text body,
+    # see server/channels/app/ratelimit.go
+    return httpx.Response(429, text="limit exceeded", headers=headers)
+
+
+def test_429_with_plain_text_body_raises_too_many_requests():
+    client = make_client(lambda request: rate_limit_response({"Retry-After": "7"}))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert excinfo.value.retry_after == 7.0
+    assert excinfo.value.status_code == 429
+    assert excinfo.value.error_id is None
+
+
+def test_429_without_headers_has_no_retry_after():
+    client = make_client(lambda request: rate_limit_response())
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert excinfo.value.retry_after is None
+
+
+def test_429_falls_back_to_ratelimit_reset_header():
+    client = make_client(lambda request: rate_limit_response({"X-RateLimit-Reset": "3"}))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert excinfo.value.retry_after == 3.0
+
+
+def test_429_prefers_retry_after_over_ratelimit_reset():
+    client = make_client(lambda request: rate_limit_response({"Retry-After": "2", "X-RateLimit-Reset": "9"}))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert excinfo.value.retry_after == 2.0
+
+
+def test_429_with_json_body_exposes_error_fields():
+    client = make_client(lambda request: error_response(429))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert excinfo.value.error_id == "api.some.error"
+    assert excinfo.value.request_id == "req1234"
 
 
 def test_post_sends_json_options():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -177,19 +177,6 @@ def test_429_with_json_body_exposes_error_fields():
     assert excinfo.value.request_id == "req1234"
 
 
-def test_post_sends_json_options():
-    seen = {}
-
-    def handler(request):
-        seen["json"] = request.read()
-        return httpx.Response(200, json={"id": "post1"})
-
-    client = make_client(handler)
-    client.post("/posts", options={"channel_id": "abc", "message": "hi"})
-
-    assert b'"channel_id"' in seen["json"]
-
-
 def test_429_is_retried_and_honors_retry_after(sleeps):
     handler, calls = sequence_handler([rate_limit_response({"Retry-After": "2"}), httpx.Response(200, json={"ok": 1})])
     client = make_client(handler, max_retries=3)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,91 @@
+import httpx
+import pytest
+
+from mattermostautodriver.client import Client
+from mattermostautodriver.exceptions import (
+    ContentTooLarge,
+    FeatureDisabled,
+    InvalidMattermostError,
+    InvalidOrMissingParameters,
+    MethodNotAllowed,
+    NoAccessTokenProvided,
+    NotEnoughPermissions,
+    ResourceNotFound,
+    UnknownMattermostError,
+)
+
+
+def make_client(handler, **extra_options):
+    options = {
+        "scheme": "http",
+        "url": "localhost",
+        "port": 8065,
+        "auth": None,
+        "debug": False,
+        "proxy": None,
+        "request_timeout": None,
+        "transport": httpx.MockTransport(handler),
+    }
+    options.update(extra_options)
+    return Client(options)
+
+
+def error_response(status, message="something failed", error_id="api.some.error", request_id="req1234"):
+    return httpx.Response(status, json={"message": message, "id": error_id, "request_id": request_id})
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (400, InvalidOrMissingParameters),
+        (401, NoAccessTokenProvided),
+        (403, NotEnoughPermissions),
+        (404, ResourceNotFound),
+        (405, MethodNotAllowed),
+        (413, ContentTooLarge),
+        (501, FeatureDisabled),
+        (418, UnknownMattermostError),
+    ],
+)
+def test_error_status_mapping(status, expected):
+    client = make_client(lambda request: error_response(status))
+
+    with pytest.raises(expected):
+        client.get("/users/me")
+
+
+def test_error_fields_are_exposed():
+    client = make_client(lambda request: error_response(404))
+
+    with pytest.raises(ResourceNotFound) as excinfo:
+        client.get("/users/unknown")
+
+    assert excinfo.value.status_code == 404
+    assert excinfo.value.error_id == "api.some.error"
+    assert excinfo.value.request_id == "req1234"
+
+
+def test_non_json_error_body_raises_invalid_error():
+    client = make_client(lambda request: httpx.Response(502, text="<html>Bad Gateway</html>"))
+
+    with pytest.raises(InvalidMattermostError):
+        client.get("/users/me")
+
+
+def test_successful_json_response_is_returned():
+    client = make_client(lambda request: httpx.Response(200, json={"id": "me"}))
+
+    assert client.get("/users/me") == {"id": "me"}
+
+
+def test_post_sends_json_options():
+    seen = {}
+
+    def handler(request):
+        seen["json"] = request.read()
+        return httpx.Response(200, json={"id": "post1"})
+
+    client = make_client(handler)
+    client.post("/posts", options={"channel_id": "abc", "message": "hi"})
+
+    assert b'"channel_id"' in seen["json"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,6 +104,15 @@ def test_429_prefers_retry_after_over_ratelimit_reset():
     assert excinfo.value.retry_after == 2.0
 
 
+def test_429_with_unparseable_retry_after_falls_back_to_ratelimit_reset():
+    client = make_client(lambda request: rate_limit_response({"Retry-After": "soon", "X-RateLimit-Reset": "3"}))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert excinfo.value.retry_after == 3.0
+
+
 def test_parse_wait_time_seconds():
     assert BaseClient._parse_wait_time("120") == 120.0
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import io
+
 import httpx
 import pytest
 
@@ -262,3 +264,31 @@ def test_requests_with_files_are_not_retried(sleeps):
         client.post("/files", files={"files": b"content"})
 
     assert len(calls) == 1
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")  # httpx warns about stream bodies via data=
+def test_put_with_stream_data_is_not_retried(sleeps):
+    handler, calls = sequence_handler([error_response(503)])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(UnknownMattermostError):
+        client.put("/imports", data=io.BytesIO(b"payload"))
+
+    assert len(calls) == 1
+
+
+def test_put_with_dict_data_is_retried(sleeps):
+    handler, calls = sequence_handler([error_response(503), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.put("/users/me/patch", data={"nickname": "x"}) == {"ok": 1}
+    assert len(calls) == 2
+
+
+def test_negative_retry_after_is_clamped_to_zero(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "-5"}), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+    assert sleeps == [0.0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,6 +25,7 @@ def make_client(handler, **extra_options):
         "debug": False,
         "proxy": None,
         "request_timeout": None,
+        "max_retries": 0,  # retry tests opt in explicitly
         "transport": httpx.MockTransport(handler),
     }
     options.update(extra_options)
@@ -144,3 +145,120 @@ def test_post_sends_json_options():
     client.post("/posts", options={"channel_id": "abc", "message": "hi"})
 
     assert b'"channel_id"' in seen["json"]
+
+
+def sequence_handler(responses):
+    """Handler returning (or raising) each item in turn, repeating the last one."""
+    calls = []
+
+    def handler(request):
+        item = responses[min(len(calls), len(responses) - 1)]
+        calls.append(request)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    return handler, calls
+
+
+@pytest.fixture
+def sleeps(monkeypatch):
+    slept = []
+    monkeypatch.setattr("mattermostautodriver.client.time.sleep", slept.append)
+    return slept
+
+
+def test_429_is_retried_and_honors_retry_after(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "2"}), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+    assert sleeps == [2.0]
+
+
+def test_429_is_retried_for_post(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"}), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.post("/posts", options={"message": "hi"}) == {"ok": 1}
+    assert len(calls) == 2
+
+
+def test_429_raises_after_retries_are_exhausted(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"})])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(TooManyRequests):
+        client.get("/users/me")
+
+    assert len(calls) == 4  # initial request + 3 retries
+
+
+def test_max_retries_zero_disables_retrying(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"})])
+    client = make_client(handler, max_retries=0)
+
+    with pytest.raises(TooManyRequests):
+        client.get("/users/me")
+
+    assert len(calls) == 1
+
+
+def test_retry_after_above_cap_raises_immediately(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "900"})])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert len(calls) == 1
+    assert sleeps == []
+    assert excinfo.value.retry_after == 900.0
+
+
+def test_get_is_retried_on_503(sleeps):
+    handler, calls = sequence_handler([error_response(503), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+    assert 0 < sleeps[0] <= 30
+
+
+def test_post_is_not_retried_on_503(sleeps):
+    handler, calls = sequence_handler([error_response(503)])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(UnknownMattermostError):
+        client.post("/posts", options={"message": "hi"})
+
+    assert len(calls) == 1
+
+
+def test_get_is_retried_on_connection_error(sleeps):
+    handler, calls = sequence_handler([httpx.ConnectError("connection refused"), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+
+
+def test_post_is_not_retried_on_connection_error(sleeps):
+    handler, calls = sequence_handler([httpx.ConnectError("connection refused")])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(httpx.ConnectError):
+        client.post("/posts", options={"message": "hi"})
+
+    assert len(calls) == 1
+
+
+def test_requests_with_files_are_not_retried(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"})])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(TooManyRequests):
+        client.post("/files", files={"files": b"content"})
+
+    assert len(calls) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -121,9 +121,16 @@ def test_parse_wait_time_clamps_negative_to_zero():
     assert BaseClient._parse_wait_time("-5") == 0.0
 
 
+# Wait values are computed against "now" twice: once when a test builds the
+# header value and once when _parse_wait_time subtracts the current time.
+# The HTTP-date and epoch formats truncate to whole seconds, eating up to one
+# second on their own; the rest is slack for test execution on slow CI runners.
+WAIT_SLACK = 5
+
+
 def test_parse_wait_time_http_date():
     value = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=60))
-    assert 55 < BaseClient._parse_wait_time(value) <= 60
+    assert 60 - WAIT_SLACK < BaseClient._parse_wait_time(value) <= 60
 
 
 def test_parse_wait_time_http_date_in_the_past():
@@ -133,7 +140,7 @@ def test_parse_wait_time_http_date_in_the_past():
 
 def test_parse_wait_time_epoch_timestamp():
     value = str(int(time.time()) + 60)
-    assert 55 < BaseClient._parse_wait_time(value) <= 61
+    assert 60 - WAIT_SLACK < BaseClient._parse_wait_time(value) <= 60
 
 
 def test_parse_wait_time_garbage_returns_none():
@@ -147,17 +154,17 @@ def test_429_with_http_date_retry_after():
     with pytest.raises(TooManyRequests) as excinfo:
         client.get("/users/me")
 
-    assert 55 < excinfo.value.retry_after <= 60
+    assert 60 - WAIT_SLACK < excinfo.value.retry_after <= 60
 
 
 def test_429_with_epoch_ratelimit_reset_is_retried(sleeps):
-    headers = {"X-RateLimit-Reset": str(int(time.time()) + 5)}
+    headers = {"X-RateLimit-Reset": str(int(time.time()) + 60)}
     handler, calls = sequence_handler([rate_limit_response(headers), httpx.Response(200, json={"ok": 1})])
-    client = make_client(handler, max_retries=3)
+    client = make_client(handler, max_retries=3, retry_max_sleep=120)
 
     assert client.get("/users/me") == {"ok": 1}
     assert len(calls) == 2
-    assert 0 < sleeps[0] <= 6
+    assert 60 - WAIT_SLACK < sleeps[0] <= 60
 
 
 def test_429_with_json_body_exposes_error_fields():
@@ -198,6 +205,7 @@ def test_429_is_retried_for_post(sleeps):
 
     assert client.post("/posts", options={"message": "hi"}) == {"ok": 1}
     assert len(calls) == 2
+    assert sleeps == [0.0]
 
 
 def test_429_raises_after_retries_are_exhausted(sleeps):
@@ -238,7 +246,8 @@ def test_get_is_retried_on_503(sleeps):
 
     assert client.get("/users/me") == {"ok": 1}
     assert len(calls) == 2
-    assert 0 < sleeps[0] <= 30
+    # First-attempt backoff is 0.5 * 2**0 * (1 + random())
+    assert 0.5 <= sleeps[0] <= 1.0
 
 
 def test_post_is_not_retried_on_503(sleeps):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,13 @@
 import io
+import time
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 
 import httpx
 import pytest
 
-from mattermostautodriver.client import Client
+from conftest import error_response, make_client, rate_limit_response, sequence_handler
+from mattermostautodriver.client import BaseClient
 from mattermostautodriver.exceptions import (
     ContentTooLarge,
     FeatureDisabled,
@@ -16,26 +20,6 @@ from mattermostautodriver.exceptions import (
     TooManyRequests,
     UnknownMattermostError,
 )
-
-
-def make_client(handler, **extra_options):
-    options = {
-        "scheme": "http",
-        "url": "localhost",
-        "port": 8065,
-        "auth": None,
-        "debug": False,
-        "proxy": None,
-        "request_timeout": None,
-        "max_retries": 0,  # retry tests opt in explicitly
-        "transport": httpx.MockTransport(handler),
-    }
-    options.update(extra_options)
-    return Client(options)
-
-
-def error_response(status, message="something failed", error_id="api.some.error", request_id="req1234"):
-    return httpx.Response(status, json={"message": message, "id": error_id, "request_id": request_id})
 
 
 @pytest.mark.parametrize(
@@ -82,12 +66,6 @@ def test_successful_json_response_is_returned():
     assert client.get("/users/me") == {"id": "me"}
 
 
-def rate_limit_response(headers=None):
-    # Mattermost replies to rate limited requests with a plain text body,
-    # see server/channels/app/ratelimit.go
-    return httpx.Response(429, text="limit exceeded", headers=headers)
-
-
 def test_429_with_plain_text_body_raises_too_many_requests():
     client = make_client(lambda request: rate_limit_response({"Retry-After": "7"}))
 
@@ -126,6 +104,53 @@ def test_429_prefers_retry_after_over_ratelimit_reset():
     assert excinfo.value.retry_after == 2.0
 
 
+def test_parse_wait_time_seconds():
+    assert BaseClient._parse_wait_time("120") == 120.0
+
+
+def test_parse_wait_time_clamps_negative_to_zero():
+    assert BaseClient._parse_wait_time("-5") == 0.0
+
+
+def test_parse_wait_time_http_date():
+    value = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=60))
+    assert 55 < BaseClient._parse_wait_time(value) <= 60
+
+
+def test_parse_wait_time_http_date_in_the_past():
+    value = format_datetime(datetime.now(timezone.utc) - timedelta(seconds=60))
+    assert BaseClient._parse_wait_time(value) == 0.0
+
+
+def test_parse_wait_time_epoch_timestamp():
+    value = str(int(time.time()) + 60)
+    assert 55 < BaseClient._parse_wait_time(value) <= 61
+
+
+def test_parse_wait_time_garbage_returns_none():
+    assert BaseClient._parse_wait_time("soon") is None
+
+
+def test_429_with_http_date_retry_after():
+    value = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=60))
+    client = make_client(lambda request: rate_limit_response({"Retry-After": value}))
+
+    with pytest.raises(TooManyRequests) as excinfo:
+        client.get("/users/me")
+
+    assert 55 < excinfo.value.retry_after <= 60
+
+
+def test_429_with_epoch_ratelimit_reset_is_retried(sleeps):
+    headers = {"X-RateLimit-Reset": str(int(time.time()) + 5)}
+    handler, calls = sequence_handler([rate_limit_response(headers), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    assert client.get("/users/me") == {"ok": 1}
+    assert len(calls) == 2
+    assert 0 < sleeps[0] <= 6
+
+
 def test_429_with_json_body_exposes_error_fields():
     client = make_client(lambda request: error_response(429))
 
@@ -147,27 +172,6 @@ def test_post_sends_json_options():
     client.post("/posts", options={"channel_id": "abc", "message": "hi"})
 
     assert b'"channel_id"' in seen["json"]
-
-
-def sequence_handler(responses):
-    """Handler returning (or raising) each item in turn, repeating the last one."""
-    calls = []
-
-    def handler(request):
-        item = responses[min(len(calls), len(responses) - 1)]
-        calls.append(request)
-        if isinstance(item, Exception):
-            raise item
-        return item
-
-    return handler, calls
-
-
-@pytest.fixture
-def sleeps(monkeypatch):
-    slept = []
-    monkeypatch.setattr("mattermostautodriver.client.time.sleep", slept.append)
-    return slept
 
 
 def test_429_is_retried_and_honors_retry_after(sleeps):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -195,6 +195,18 @@ def test_429_is_retried_for_post(sleeps):
     assert sleeps == [0.0]
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")  # httpx warns about stream bodies via data=
+def test_429_is_not_retried_for_post_with_stream_data(sleeps):
+    handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"}), httpx.Response(200, json={"ok": 1})])
+    client = make_client(handler, max_retries=3)
+
+    with pytest.raises(TooManyRequests):
+        client.post("/imports", data=io.BytesIO(b"payload"))
+
+    assert len(calls) == 1
+    assert sleeps == []
+
+
 def test_429_raises_after_retries_are_exhausted(sleeps):
     handler, calls = sequence_handler([rate_limit_response({"Retry-After": "0"})])
     client = make_client(handler, max_retries=3)


### PR DESCRIPTION
Following summary is AI generated (but read and verified). Do you have an opinion @unode?

## Summary

Implements the retry behavior discussed in https://github.com/embl-bio-it/python-mattermost-autodriver/issues/42: the driver now automatically retries requests that fail due to server-side rate limiting or transient errors, following the conventions of established SDKs (slack_sdk, botocore, the OpenAI/Anthropic clients) rather than pulling in a retry library.

## Retry policy

| Failure | Retried? | Notes |
|---|---|---|
| HTTP 429 | All methods | Safe for any method — the server rejected the request outright. Honors `Retry-After` / `X-RateLimit-Reset`. |
| Connection errors, 502/503/504 | Idempotent methods only (GET/PUT/DELETE/HEAD) | A POST may already have been processed; retrying risks duplicated messages. |
| Requests with `files` or streaming `data=` bodies | Never | Stream bodies are consumed on first send; a replay would transmit an empty body. |
| 401 and other 4xx | Never | Deterministic failures; retrying cannot help. |

Two new driver options control this: `max_retries` (default 3, `0` disables) and `retry_max_sleep` (default 30 s, caps any single wait — if the server requests a longer wait the request fails immediately instead of blocking).

## New `TooManyRequests` exception

Mattermost's rate limiter replies with a plain-text body rather than the standard JSON error ([`ratelimit.go`](https://github.com/mattermost/mattermost/blob/master/server/channels/app/ratelimit.go)), so 429s previously surfaced as `InvalidMattermostError` or `UnknownMattermostError` and could not be caught cleanly. 429 detection now happens from the status code and headers before body parsing, raising `TooManyRequests` with a `retry_after` attribute. Wait values are parsed in all three conventions found in the wild: delay-seconds, HTTP-date, and absolute unix timestamps.

**Backwards incompatible:** code catching `UnknownMattermostError` / `InvalidMattermostError` for 429s must switch to `TooManyRequests` (noted in the changelog).

## Tests and CI

The PR adds the project's first test suite: 46 pytest tests covering the existing status→exception mapping and the new retry behavior for both `Client` and `AsyncClient`, using `httpx.MockTransport` (no new runtime dependencies — dev dependencies live in `requirements-dev.txt`). A new workflow runs the suite on pull requests across Python 3.10–3.13.

## Notes for review

- Retry logic is hand-rolled (~80 lines shared in `BaseClient`) rather than a Tenacity dependency — the decision needs the response object (status, headers, original method), and sync/async variants mirror the existing client split.
- Websocket reconnection is untouched; token-refresh-on-401 is deliberately out of scope (it is a re-authentication concern, not a retry concern).