### PR TITLE
Pagination helper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,8 +23,8 @@ Code
 - Add ``TypedDriver.paginate`` and ``AsyncTypedDriver.paginate`` to lazily
   iterate over all items of paginated endpoints without manual page handling.
   Supports ``page``/``per_page`` endpoints out of the box, responses wrapping
-  the items in an object via ``items=``, and cursor based endpoints via
-  ``next_args=``.
+  the items in an object via ``items_from=``, and cursor based endpoints via
+  ``next_params=``.
 
 Documentation
 '''''''''''''

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,10 @@ Code
   iterate over all items of paginated endpoints without manual page handling.
   Supports ``page``/``per_page`` endpoints out of the box, responses wrapping
   the items in an object via ``items_from=``, and cursor based endpoints via
-  ``next_params=``.
+  ``next_params=``. When the server ignores ``page``/``per_page`` (endpoints
+  requiring a ``paginate=True`` flag, or ``since=`` on
+  ``posts.get_posts_for_channel``) the repeated page raises ``RuntimeError``
+  instead of iterating forever.
 
 Documentation
 '''''''''''''

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,11 +20,17 @@ Code
   as its ``retry_after`` attribute. Previously a 429 raised
   ``UnknownMattermostError`` or ``InvalidMattermostError`` depending on the
   response body.
+- Add ``TypedDriver.paginate`` and ``AsyncTypedDriver.paginate`` to lazily
+  iterate over all items of paginated endpoints without manual page handling.
+  Supports ``page``/``per_page`` endpoints out of the box, responses wrapping
+  the items in an object via ``items=``, and cursor based endpoints via
+  ``next_args=``.
 
 Documentation
 '''''''''''''
 
 - Document the automatic retry behavior and the ``TooManyRequests`` exception.
+- Add a pagination documentation page describing ``driver.paginate()``.
 
 Maintenance
 '''''''''''

--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,15 @@ Usage
     # Query parameters
     foo.users.get_users(page=0, per_page=60)
 
+    """
+    Endpoints accepting page/per_page can be iterated without manual paging
+    using `paginate`, which lazily fetches pages as iteration progresses.
+    See https://embl-bio-it.github.io/python-mattermost-autodriver/pagination.html
+    for details, including cursor based endpoints and wrapped responses.
+    """
+    for user in foo.paginate(foo.users.get_users, in_team='some_team_id'):
+        print(user['username'])
+
     # Request body fields
     foo.channels.create_channel(
         team_id='some_team_id',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ mattermostautodriver documentation
    :caption: Contents:
 
    endpoints
+   pagination
    api_deprecation
    changelog
    contributing

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -18,8 +18,11 @@ The same method exists on ``AsyncTypedDriver``, returning an async iterator:
     async for user in driver.paginate(driver.users.get_users, in_team=team_id):
         print(user["username"])
 
-Positional and keyword arguments are passed through to the endpoint method,
-and ``per_page`` defaults to 200. Iteration stops when a page returns fewer
+All endpoint parameters — including path parameters such as ``channel_id``
+— are passed as keyword arguments and forwarded to the endpoint method.
+Positional arguments raise ``TypeError`` before any request is made, as
+they could bind to ``page``/``per_page`` or the wrong query parameter.
+``per_page`` defaults to 200. Iteration stops when a page returns fewer
 items than ``per_page``. Values above 200 — the most the Mattermost server
 serves per page — are silently capped by the server, so with a larger
 ``per_page`` a short page is not conclusive and iteration only stops on an
@@ -38,7 +41,7 @@ returning the list:
 .. code:: python
 
     for thread in driver.paginate(
-        driver.threads.get_user_threads, user_id, team_id, items="threads"
+        driver.threads.get_user_threads, user_id=user_id, team_id=team_id, items="threads"
     ):
         print(thread["id"])
 
@@ -57,7 +60,8 @@ history:
 .. code:: python
 
     for post in driver.paginate(
-        driver.posts.get_posts_for_channel, channel_id,
+        driver.posts.get_posts_for_channel,
+        channel_id=channel_id,
         items=lambda r: [r["posts"][pid] for pid in r["order"]],
         next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
     ):
@@ -82,7 +86,8 @@ endpoints may never terminate:
 .. code:: python
 
     for channel_id, groups in driver.paginate(
-        driver.groups.get_groups_associated_to_channels_by_team, team_id,
+        driver.groups.get_groups_associated_to_channels_by_team,
+        team_id=team_id,
         paginate=True,
         items=lambda r: list(r["groups"].items()),
     ):

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -51,20 +51,23 @@ A few endpoints paginate with cursors instead of page numbers, such as the
 ``before``/``after`` post IDs of ``posts.get_posts_for_channel`` or the
 keyset parameters of the reporting endpoints. Pass ``next_args=``, a callable
 that receives each response and returns the keyword arguments for the next
-call — or ``None`` to stop. Walking a channel's full post history:
+call — or ``None`` (or an empty dict) to stop. Walking a channel's full post
+history:
 
 .. code:: python
 
     for post in driver.paginate(
         driver.posts.get_posts_for_channel, channel_id,
         items=lambda r: [r["posts"][pid] for pid in r["order"]],
-        next_args=lambda r: {"before": r["order"][-1]} if r["prev_post_id"] else None,
+        next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
     ):
         print(post["message"])
 
-In cursor mode the ``page``/``per_page`` requirement does not apply;
-``per_page`` is only forwarded to the endpoint when explicitly given.
-Iteration also stops when a page contains no items.
+In cursor mode the ``page``/``per_page`` requirement does not apply, and
+``next_args`` alone decides when iteration ends: it is consulted even for
+pages without items, so an ``items=`` callable that filters a whole page
+away does not end the iteration early. ``per_page`` defaults to 200 when
+the endpoint accepts it and is otherwise omitted.
 
 Endpoints with a pagination flag
 --------------------------------

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -26,33 +26,35 @@ they could bind to ``page``/``per_page`` or the wrong query parameter.
 items than ``per_page``. Values above 200 — the most the Mattermost server
 serves per page — are silently capped by the server, so with a larger
 ``per_page`` a short page is not conclusive and iteration only stops on an
-empty or shrinking page. ``page=`` may be passed to start at a later page,
-and ``max_pages=`` caps the number of requests.
+empty or shrinking page. ``start_page=`` may be passed to start at a later
+page, and ``max_pages=`` caps the number of requests. ``page=`` itself is
+never passed through and raises ``TypeError`` — call the method directly
+to fetch a single page.
 
 Wrapped responses
 -----------------
 
 Some endpoints do not return a plain list but wrap the items in an object,
 for example ``threads.get_user_threads`` returns
-``{"threads": [...], "total": ...}``. Use ``items=`` to say where the items
+``{"threads": [...], "total": ...}``. Use ``items_from=`` to say where the items
 are — either a response key or a callable receiving the response and
 returning the list:
 
 .. code:: python
 
     for thread in driver.paginate(
-        driver.threads.get_user_threads, user_id=user_id, team_id=team_id, items="threads"
+        driver.threads.get_user_threads, user_id=user_id, team_id=team_id, items_from="threads"
     ):
         print(thread["id"])
 
-Without ``items=``, a non-list response raises ``TypeError``.
+Without ``items_from=``, a non-list response raises ``TypeError``.
 
 Cursor based endpoints
 ----------------------
 
 A few endpoints paginate with cursors instead of page numbers, such as the
 ``before``/``after`` post IDs of ``posts.get_posts_for_channel`` or the
-keyset parameters of the reporting endpoints. Pass ``next_args=``, a callable
+keyset parameters of the reporting endpoints. Pass ``next_params=``, a callable
 that receives each response and returns the keyword arguments for the next
 call — or ``None`` (or an empty dict) to stop. Walking a channel's full post
 history:
@@ -62,23 +64,23 @@ history:
     for post in driver.paginate(
         driver.posts.get_posts_for_channel,
         channel_id=channel_id,
-        items=lambda r: [r["posts"][pid] for pid in r["order"]],
-        next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
+        items_from=lambda r: [r["posts"][pid] for pid in r["order"]],
+        next_params=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
     ):
         print(post["message"])
 
 In cursor mode the ``page``/``per_page`` requirement does not apply, and
-``next_args`` alone decides when iteration ends: it is consulted even for
-pages without items, so an ``items=`` callable that filters a whole page
+``next_params`` alone decides when iteration ends: it is consulted even for
+pages without items, so an ``items_from=`` callable that filters a whole page
 away does not end the iteration early. Each returned dict *replaces* the
 previous one rather than merging with it, so cursor keys from earlier
-pages never leak into later requests — a ``next_args`` may e.g. switch
+pages never leak into later requests — a ``next_params`` may e.g. switch
 from ``after`` to ``before`` mid-walk, and a cursor passed directly to
 ``paginate()`` (such as a starting ``before=``) is overridden once
-``next_args`` takes over. ``per_page`` defaults to 200 when the endpoint
-accepts it and is otherwise omitted. Passing ``page=`` in cursor mode
-raises ``TypeError`` — it would be re-sent verbatim on every request,
-skipping data in each cursor window; drive the paging via ``next_args``.
+``next_params`` takes over. ``per_page`` defaults to 200 when the endpoint
+accepts it and is otherwise omitted. ``start_page=`` applies to offset
+pagination only and raises ``TypeError`` here — ``next_params`` alone
+drives the paging.
 
 Endpoints with a pagination flag
 --------------------------------
@@ -96,13 +98,13 @@ endpoints may never terminate:
         driver.groups.get_groups_associated_to_channels_by_team,
         team_id=team_id,
         paginate=True,
-        items=lambda r: list(r["groups"].items()),
+        items_from=lambda r: list(r["groups"].items()),
     ):
         ...
 
 Unsupported methods
 -------------------
 
-Passing a method that accepts neither ``page``/``per_page`` nor ``next_args=``
+Passing a method that accepts neither ``page``/``per_page`` nor ``next_params=``
 raises ``TypeError`` immediately, before any request is made. Such endpoints
 are not paginated — call them directly.

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -76,7 +76,9 @@ pages never leak into later requests — a ``next_args`` may e.g. switch
 from ``after`` to ``before`` mid-walk, and a cursor passed directly to
 ``paginate()`` (such as a starting ``before=``) is overridden once
 ``next_args`` takes over. ``per_page`` defaults to 200 when the endpoint
-accepts it and is otherwise omitted.
+accepts it and is otherwise omitted. Passing ``page=`` in cursor mode
+raises ``TypeError`` — it would be re-sent verbatim on every request,
+skipping data in each cursor window; drive the paging via ``next_args``.
 
 Endpoints with a pagination flag
 --------------------------------

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -1,0 +1,71 @@
+Pagination
+==========
+
+Many Mattermost endpoints return results one page at a time, using ``page``
+and ``per_page`` query parameters. ``driver.paginate()`` wraps any such
+endpoint method and lazily iterates over the items of every page — the next
+page is only requested when iteration reaches it.
+
+.. code:: python
+
+    for user in driver.paginate(driver.users.get_users, in_team=team_id):
+        print(user["username"])
+
+The same method exists on ``AsyncTypedDriver``, returning an async iterator:
+
+.. code:: python
+
+    async for user in driver.paginate(driver.users.get_users, in_team=team_id):
+        print(user["username"])
+
+Positional and keyword arguments are passed through to the endpoint method.
+Iteration stops when a page returns fewer items than ``per_page``
+(default 200). ``page=`` may be passed to start at a later page, and
+``max_pages=`` caps the number of requests.
+
+Wrapped responses
+-----------------
+
+Some endpoints do not return a plain list but wrap the items in an object,
+for example ``threads.get_user_threads`` returns
+``{"threads": [...], "total": ...}``. Use ``items=`` to say where the items
+are — either a response key or a callable receiving the response and
+returning the list:
+
+.. code:: python
+
+    for thread in driver.paginate(
+        driver.threads.get_user_threads, user_id, team_id, items="threads"
+    ):
+        print(thread["id"])
+
+Without ``items=``, a non-list response raises ``TypeError``.
+
+Cursor based endpoints
+----------------------
+
+A few endpoints paginate with cursors instead of page numbers, such as the
+``before``/``after`` post IDs of ``posts.get_posts_for_channel`` or the
+keyset parameters of the reporting endpoints. Pass ``next_args=``, a callable
+that receives each response and returns the keyword arguments for the next
+call — or ``None`` to stop. Walking a channel's full post history:
+
+.. code:: python
+
+    for post in driver.paginate(
+        driver.posts.get_posts_for_channel, channel_id,
+        items=lambda r: [r["posts"][pid] for pid in r["order"]],
+        next_args=lambda r: {"before": r["order"][-1]} if r["prev_post_id"] else None,
+    ):
+        print(post["message"])
+
+In cursor mode the ``page``/``per_page`` requirement does not apply;
+``per_page`` is only forwarded to the endpoint when explicitly given.
+Iteration also stops when a page contains no items.
+
+Unsupported methods
+-------------------
+
+Passing a method that accepts neither ``page``/``per_page`` nor ``next_args=``
+raises ``TypeError`` immediately, before any request is made. Such endpoints
+are not paginated — call them directly.

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -66,6 +66,25 @@ In cursor mode the ``page``/``per_page`` requirement does not apply;
 ``per_page`` is only forwarded to the endpoint when explicitly given.
 Iteration also stops when a page contains no items.
 
+Endpoints with a pagination flag
+--------------------------------
+
+A small number of endpoints accept ``page``/``per_page`` but only apply them
+when an additional flag is set — for example
+``groups.get_groups_associated_to_channels_by_team`` requires ``paginate=True``,
+otherwise every page returns the identical full result set. Such flags pass
+through like any other keyword argument; without the flag, iterating these
+endpoints may never terminate:
+
+.. code:: python
+
+    for channel_id, groups in driver.paginate(
+        driver.groups.get_groups_associated_to_channels_by_team, team_id,
+        paginate=True,
+        items=lambda r: list(r["groups"].items()),
+    ):
+        ...
+
 Unsupported methods
 -------------------
 

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -18,10 +18,13 @@ The same method exists on ``AsyncTypedDriver``, returning an async iterator:
     async for user in driver.paginate(driver.users.get_users, in_team=team_id):
         print(user["username"])
 
-Positional and keyword arguments are passed through to the endpoint method.
-Iteration stops when a page returns fewer items than ``per_page``
-(default 200). ``page=`` may be passed to start at a later page, and
-``max_pages=`` caps the number of requests.
+Positional and keyword arguments are passed through to the endpoint method,
+and ``per_page`` defaults to 200. Iteration stops when a page returns fewer
+items than ``per_page``. Values above 200 — the most the Mattermost server
+serves per page — are silently capped by the server, so with a larger
+``per_page`` a short page is not conclusive and iteration only stops on an
+empty or shrinking page. ``page=`` may be passed to start at a later page,
+and ``max_pages=`` caps the number of requests.
 
 Wrapped responses
 -----------------

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -70,8 +70,13 @@ history:
 In cursor mode the ``page``/``per_page`` requirement does not apply, and
 ``next_args`` alone decides when iteration ends: it is consulted even for
 pages without items, so an ``items=`` callable that filters a whole page
-away does not end the iteration early. ``per_page`` defaults to 200 when
-the endpoint accepts it and is otherwise omitted.
+away does not end the iteration early. Each returned dict *replaces* the
+previous one rather than merging with it, so cursor keys from earlier
+pages never leak into later requests — a ``next_args`` may e.g. switch
+from ``after`` to ``before`` mid-walk, and a cursor passed directly to
+``paginate()`` (such as a starting ``before=``) is overridden once
+``next_args`` takes over. ``per_page`` defaults to 200 when the endpoint
+accepts it and is otherwise omitted.
 
 Endpoints with a pagination flag
 --------------------------------

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -82,15 +82,25 @@ accepts it and is otherwise omitted. ``start_page=`` applies to offset
 pagination only and raises ``TypeError`` here — ``next_params`` alone
 drives the paging.
 
-Endpoints with a pagination flag
+Endpoints ignoring page/per_page
 --------------------------------
 
-A small number of endpoints accept ``page``/``per_page`` but only apply them
-when an additional flag is set — for example
-``groups.get_groups_associated_to_channels_by_team`` requires ``paginate=True``,
-otherwise every page returns the identical full result set. Such flags pass
-through like any other keyword argument; without the flag, iterating these
-endpoints may never terminate:
+A small number of endpoints accept ``page``/``per_page`` but ignore them in
+some configurations, serving the identical full result set for every page.
+``paginate()`` detects the repeated page and raises ``RuntimeError`` after the
+second request instead of looping forever. This happens in two situations:
+
+- Endpoints that only paginate when an additional flag is set — for example
+  ``groups.get_groups_associated_to_channels_by_team`` requires
+  ``paginate=True``. Such flags pass through like any other keyword argument.
+- Parameters that disable pagination server side — for example a non-zero
+  ``since=`` makes ``posts.get_posts_for_channel`` return all matching posts
+  in a single response. Call such methods directly instead of paginating.
+  (Other endpoints, such as ``groups.get_groups`` and
+  ``threads.get_user_threads``, treat ``since=`` as a plain filter and
+  paginate normally.)
+
+With the required flag, the flagged endpoints paginate like any other:
 
 .. code:: python
 

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -122,7 +122,8 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         .. code:: python
 
                 for post in driver.paginate(
-                        driver.posts.get_posts_for_channel, channel_id,
+                        driver.posts.get_posts_for_channel,
+                        channel_id=channel_id,
                         items=lambda r: [r["posts"][pid] for pid in r["order"]],
                         next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
                 ):
@@ -130,8 +131,12 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
 
         Methods that support neither raise ``TypeError`` before any request is made.
 
+        All endpoint parameters — including path parameters such as
+        ``channel_id`` — must be passed as keyword arguments; positional
+        arguments raise ``TypeError`` before any request, as they could
+        bind to ``page``/``per_page`` or the wrong query parameter.
+
         :param method: The endpoint method to paginate, e.g. ``driver.users.get_users``
-        :param args: Positional arguments (e.g. path parameters) passed through to ``method``
         :param per_page: Page size, defaults to 200. In cursor mode the default
                 is only applied when ``method`` accepts a ``per_page`` parameter.
         :param items: Where to find the items when the response is not a plain

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from ..client import AsyncClient, Client
+from ..pagination import apaginate as _apaginate, paginate as _paginate
 from ..websocket import Websocket
 
 from .endpoint_base import TypedBaseDriverWithEndpoints
@@ -91,6 +92,56 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
             self.client.username = result["username"]
 
         return result
+
+    def paginate(self, method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+        """
+        Lazily iterate over every item of a paginated endpoint method.
+
+        Wraps any endpoint method accepting ``page``/``per_page`` and yields
+        the items of each page, fetching the next page only when iteration
+        reaches it. Iteration stops when a page returns fewer items than
+        ``per_page``.
+
+        .. code:: python
+
+                for user in driver.paginate(driver.users.get_users, in_team=team_id):
+                        print(user["username"])
+
+        Endpoints wrapping the items in an object need ``items=`` to say where
+        the items are, e.g. ``items="threads"`` for ``threads.get_user_threads``.
+
+        Cursor based endpoints (no ``page``/``per_page``, or cursor parameters
+        such as ``before``/``after``) are supported by passing ``next_args=``,
+        a callable receiving each response and returning the extra keyword
+        arguments for the next call, or ``None`` to stop:
+
+        .. code:: python
+
+                for post in driver.paginate(
+                        driver.posts.get_posts_for_channel, channel_id,
+                        items=lambda r: [r["posts"][pid] for pid in r["order"]],
+                        next_args=lambda r: {"before": r["order"][-1]} if r["prev_post_id"] else None,
+                ):
+                        print(post["message"])
+
+        Methods that support neither raise ``TypeError`` before any request is made.
+
+        :param method: The endpoint method to paginate, e.g. ``driver.users.get_users``
+        :param args: Positional arguments (e.g. path parameters) passed through to ``method``
+        :param per_page: Page size, defaults to 200. In cursor mode it is only
+                forwarded to ``method`` when explicitly given.
+        :param items: Where to find the items when the response is not a plain
+                list: a response key or a callable ``response -> list``
+        :param next_args: Enables cursor mode: callable ``response -> dict | None``
+                returning the keyword arguments for the next call
+        :param max_pages: Optional hard limit on the number of pages fetched
+        :param kwargs: Keyword arguments passed through to ``method``. ``page``
+                may be given as the starting page (defaults to 0).
+        :return: Generator yielding one item at a time
+        """
+        return _paginate(
+            method, *args, per_page=per_page, items=items, next_args=next_args, max_pages=max_pages, **kwargs
+        )
 
     def logout(self):
         """
@@ -191,6 +242,24 @@ class AsyncTypedDriver(TypedBaseDriverWithEndpoints):
             self.client.username = result["username"]
 
         return result
+
+    def paginate(self, method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+        """
+        Lazily iterate over every item of a paginated endpoint method.
+
+        Asynchronous variant of :meth:`TypedDriver.paginate` — identical
+        parameters, but returns an async generator:
+
+        .. code:: python
+
+                async for user in driver.paginate(driver.users.get_users, in_team=team_id):
+                        print(user["username"])
+
+        :return: Async generator yielding one item at a time
+        """
+        return _apaginate(
+            method, *args, per_page=per_page, items=items, next_args=next_args, max_pages=max_pages, **kwargs
+        )
 
     async def logout(self):
         """

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -115,14 +115,16 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         Cursor based endpoints (no ``page``/``per_page``, or cursor parameters
         such as ``before``/``after``) are supported by passing ``next_args=``,
         a callable receiving each response and returning the extra keyword
-        arguments for the next call, or ``None`` to stop:
+        arguments for the next call, or ``None`` (or an empty dict) to stop.
+        ``next_args`` alone decides when iteration ends — it is consulted even
+        for pages without items:
 
         .. code:: python
 
                 for post in driver.paginate(
                         driver.posts.get_posts_for_channel, channel_id,
                         items=lambda r: [r["posts"][pid] for pid in r["order"]],
-                        next_args=lambda r: {"before": r["order"][-1]} if r["prev_post_id"] else None,
+                        next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
                 ):
                         print(post["message"])
 

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -130,8 +130,8 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
 
         :param method: The endpoint method to paginate, e.g. ``driver.users.get_users``
         :param args: Positional arguments (e.g. path parameters) passed through to ``method``
-        :param per_page: Page size, defaults to 200. In cursor mode it is only
-                forwarded to ``method`` when explicitly given.
+        :param per_page: Page size, defaults to 200. In cursor mode the default
+                is only applied when ``method`` accepts a ``per_page`` parameter.
         :param items: Where to find the items when the response is not a plain
                 list: a response key or a callable ``response -> list``
         :param next_args: Enables cursor mode: callable ``response -> dict | None``

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -117,7 +117,8 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         a callable receiving each response and returning the extra keyword
         arguments for the next call, or ``None`` (or an empty dict) to stop.
         ``next_args`` alone decides when iteration ends — it is consulted even
-        for pages without items:
+        for pages without items. Each returned dict replaces the previous one
+        rather than merging with it:
 
         .. code:: python
 

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -145,8 +145,10 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         :param next_args: Enables cursor mode: callable ``response -> dict | None``
                 returning the keyword arguments for the next call
         :param max_pages: Optional hard limit on the number of pages fetched
-        :param kwargs: Keyword arguments passed through to ``method``. ``page``
-                may be given as the starting page (defaults to 0).
+        :param kwargs: Keyword arguments passed through to ``method``. In offset
+                mode ``page`` may be given as the starting page (defaults to 0);
+                in cursor mode passing ``page`` raises ``TypeError`` — drive the
+                paging via ``next_args`` instead.
         :return: Generator yielding one item at a time
         """
         return _paginate(

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -100,7 +100,9 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         Wraps any endpoint method accepting ``page``/``per_page`` and yields
         the items of each page, fetching the next page only when iteration
         reaches it. Iteration stops when a page returns fewer items than
-        ``per_page``.
+        ``per_page``. As the server silently caps ``per_page`` above 200,
+        larger values make a short page inconclusive and iteration only
+        stops on an empty or shrinking page.
 
         .. code:: python
 

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -97,45 +97,14 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         """
         Lazily iterate over every item of a paginated endpoint method.
 
-        Wraps any endpoint method accepting ``page``/``per_page`` and yields
-        the items of each page, fetching the next page only when iteration
-        reaches it. Iteration stops when a page returns fewer items than
-        ``per_page``. As the server silently caps ``per_page`` above 200,
-        larger values make a short page inconclusive and iteration only
-        stops on an empty or shrinking page.
-
         .. code:: python
 
                 for user in driver.paginate(driver.users.get_users, in_team=team_id):
                         print(user["username"])
 
-        Endpoints wrapping the items in an object need ``items=`` to say where
-        the items are, e.g. ``items="threads"`` for ``threads.get_user_threads``.
-
-        Cursor based endpoints (no ``page``/``per_page``, or cursor parameters
-        such as ``before``/``after``) are supported by passing ``next_args=``,
-        a callable receiving each response and returning the extra keyword
-        arguments for the next call, or ``None`` (or an empty dict) to stop.
-        ``next_args`` alone decides when iteration ends — it is consulted even
-        for pages without items. Each returned dict replaces the previous one
-        rather than merging with it:
-
-        .. code:: python
-
-                for post in driver.paginate(
-                        driver.posts.get_posts_for_channel,
-                        channel_id=channel_id,
-                        items=lambda r: [r["posts"][pid] for pid in r["order"]],
-                        next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
-                ):
-                        print(post["message"])
-
-        Methods that support neither raise ``TypeError`` before any request is made.
-
-        All endpoint parameters — including path parameters such as
-        ``channel_id`` — must be passed as keyword arguments; positional
-        arguments raise ``TypeError`` before any request, as they could
-        bind to ``page``/``per_page`` or the wrong query parameter.
+        See :doc:`pagination </pagination>` for the full guide, including the
+        termination rules, wrapped responses, cursor based endpoints and
+        endpoints requiring a pagination flag.
 
         :param method: The endpoint method to paginate, e.g. ``driver.users.get_users``
         :param per_page: Page size, defaults to 200. In cursor mode the default
@@ -143,12 +112,13 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         :param items: Where to find the items when the response is not a plain
                 list: a response key or a callable ``response -> list``
         :param next_args: Enables cursor mode: callable ``response -> dict | None``
-                returning the keyword arguments for the next call
+                returning the keyword arguments for the next call. Each dict
+                replaces the previous one; ``None`` (or an empty dict) stops.
         :param max_pages: Optional hard limit on the number of pages fetched
-        :param kwargs: Keyword arguments passed through to ``method``. In offset
-                mode ``page`` may be given as the starting page (defaults to 0);
-                in cursor mode passing ``page`` raises ``TypeError`` — drive the
-                paging via ``next_args`` instead.
+        :param kwargs: Keyword arguments passed through to ``method``. All
+                endpoint parameters, including path parameters, must be
+                keywords. In offset mode ``page`` may be given as the starting
+                page (defaults to 0).
         :return: Generator yielding one item at a time
         """
         return _paginate(

--- a/src/mattermostautodriver/driver/driver.py
+++ b/src/mattermostautodriver/driver/driver.py
@@ -93,7 +93,9 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
 
         return result
 
-    def paginate(self, method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+    def paginate(
+        self, method, /, *args, per_page=None, items_from=None, next_params=None, max_pages=None, start_page=0, **kwargs
+    ):
         """
         Lazily iterate over every item of a paginated endpoint method.
 
@@ -109,20 +111,28 @@ class TypedDriver(TypedBaseDriverWithEndpoints):
         :param method: The endpoint method to paginate, e.g. ``driver.users.get_users``
         :param per_page: Page size, defaults to 200. In cursor mode the default
                 is only applied when ``method`` accepts a ``per_page`` parameter.
-        :param items: Where to find the items when the response is not a plain
-                list: a response key or a callable ``response -> list``
-        :param next_args: Enables cursor mode: callable ``response -> dict | None``
-                returning the keyword arguments for the next call. Each dict
-                replaces the previous one; ``None`` (or an empty dict) stops.
+        :param items_from: Where to find the items when the response is not a
+                plain list: a response key or a callable ``response -> list``
+        :param next_params: Enables cursor mode: callable ``response -> dict | None``
+                returning the parameters for the next call. Each dict replaces
+                the previous one; ``None`` (or an empty dict) stops.
         :param max_pages: Optional hard limit on the number of pages fetched
+        :param start_page: Page to start from in offset mode (defaults to 0)
         :param kwargs: Keyword arguments passed through to ``method``. All
                 endpoint parameters, including path parameters, must be
-                keywords. In offset mode ``page`` may be given as the starting
-                page (defaults to 0).
+                keywords. ``page`` is not passed through — use ``start_page``,
+                or call the method directly for a single page.
         :return: Generator yielding one item at a time
         """
         return _paginate(
-            method, *args, per_page=per_page, items=items, next_args=next_args, max_pages=max_pages, **kwargs
+            method,
+            *args,
+            per_page=per_page,
+            items_from=items_from,
+            next_params=next_params,
+            max_pages=max_pages,
+            start_page=start_page,
+            **kwargs,
         )
 
     def logout(self):
@@ -225,7 +235,9 @@ class AsyncTypedDriver(TypedBaseDriverWithEndpoints):
 
         return result
 
-    def paginate(self, method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+    def paginate(
+        self, method, /, *args, per_page=None, items_from=None, next_params=None, max_pages=None, start_page=0, **kwargs
+    ):
         """
         Lazily iterate over every item of a paginated endpoint method.
 
@@ -240,7 +252,14 @@ class AsyncTypedDriver(TypedBaseDriverWithEndpoints):
         :return: Async generator yielding one item at a time
         """
         return _apaginate(
-            method, *args, per_page=per_page, items=items, next_args=next_args, max_pages=max_pages, **kwargs
+            method,
+            *args,
+            per_page=per_page,
+            items_from=items_from,
+            next_params=next_params,
+            max_pages=max_pages,
+            start_page=start_page,
+            **kwargs,
         )
 
     async def logout(self):

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -20,117 +20,106 @@ def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages
     for parameter documentation.
     """
     _validate(method, args, kwargs, items, next_args)
-
-    if next_args is not None:
-        per_page = _cursor_per_page(method, per_page)
-        if per_page is not None:
-            kwargs["per_page"] = per_page
-        return _paginate_cursor(method, kwargs, items, next_args, max_pages)
-
-    return _paginate_offset(method, kwargs, items, per_page, max_pages)
+    return _paginate_sync(method, _make_pager(method, kwargs, per_page, next_args), items, max_pages)
 
 
 def apaginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
     """Asynchronous variant of :func:`paginate` returning an async iterator."""
     _validate(method, args, kwargs, items, next_args)
+    return _paginate_async(method, _make_pager(method, kwargs, per_page, next_args), items, max_pages)
 
+
+def _paginate_sync(method, pager, items, max_pages):
+    pages_fetched = 0
+
+    while max_pages is None or pages_fetched < max_pages:
+        response = method(**pager.request_kwargs())
+        batch = _extract_items(response, items)
+        pages_fetched += 1
+
+        yield from batch
+
+        if not pager.advance(response, batch):
+            return
+
+
+async def _paginate_async(method, pager, items, max_pages):
+    pages_fetched = 0
+
+    while max_pages is None or pages_fetched < max_pages:
+        response = await method(**pager.request_kwargs())
+        batch = _extract_items(response, items)
+        pages_fetched += 1
+
+        for item in batch:
+            yield item
+
+        if not pager.advance(response, batch):
+            return
+
+
+def _make_pager(method, kwargs, per_page, next_args):
     if next_args is not None:
-        per_page = _cursor_per_page(method, per_page)
+        return _CursorPager(kwargs, _cursor_per_page(method, per_page), next_args)
+    return _OffsetPager(kwargs, per_page)
+
+
+class _OffsetPager:
+    """Paging decisions for page/per_page based endpoints."""
+
+    def __init__(self, kwargs, per_page):
+        self.kwargs = kwargs
+        self.page = kwargs.pop("page", None) or 0
+        # Default to the largest page size the server serves, not its default of 60
+        self.per_page = per_page if per_page is not None else MAX_PER_PAGE
+        self.largest_batch = 0
+
+    def request_kwargs(self):
+        return {**self.kwargs, "page": self.page, "per_page": self.per_page}
+
+    def advance(self, response, batch):
+        """Advance to the next page, or return False when this was the last one.
+
+        Up to the server's cap the requested per_page is honored, so a short
+        page is the last one. Above the cap a short page is not conclusive
+        and only an empty or shrinking page ends the iteration.
+        """
+        limit = self.per_page if self.per_page <= MAX_PER_PAGE else self.largest_batch
+        if not batch or len(batch) < limit:
+            return False
+
+        self.largest_batch = max(self.largest_batch, len(batch))
+        self.page += 1
+        return True
+
+
+class _CursorPager:
+    """Paging decisions for cursor based endpoints, driven by next_args."""
+
+    def __init__(self, kwargs, per_page, next_args):
+        self.kwargs = kwargs
         if per_page is not None:
-            kwargs["per_page"] = per_page
-        return _apaginate_cursor(method, kwargs, items, next_args, max_pages)
+            self.kwargs["per_page"] = per_page
+        self.cursor_kwargs = {}
+        self.next_args = next_args
 
-    return _apaginate_offset(method, kwargs, items, per_page, max_pages)
+    def request_kwargs(self):
+        return {**self.kwargs, **self.cursor_kwargs}
 
+    def advance(self, response, batch):
+        """Advance to the next cursor, or return False when next_args stops.
 
-def _paginate_offset(method, kwargs, items, per_page, max_pages):
-    page, per_page = _offset_start(kwargs, per_page)
-    pages_fetched = 0
-    largest_batch = 0
-
-    while max_pages is None or pages_fetched < max_pages:
-        batch = _extract_items(method(page=page, per_page=per_page, **kwargs), items)
-        pages_fetched += 1
-
-        yield from batch
-
-        # Up to the server's cap the requested per_page is honored, so a short
-        # page is the last one. Above the cap a short page is not conclusive
-        # and only an empty or shrinking page ends the iteration.
-        limit = per_page if per_page <= MAX_PER_PAGE else largest_batch
-        if not batch or len(batch) < limit:
-            return
-
-        largest_batch = max(largest_batch, len(batch))
-        page += 1
-
-
-async def _apaginate_offset(method, kwargs, items, per_page, max_pages):
-    page, per_page = _offset_start(kwargs, per_page)
-    pages_fetched = 0
-    largest_batch = 0
-
-    while max_pages is None or pages_fetched < max_pages:
-        batch = _extract_items(await method(page=page, per_page=per_page, **kwargs), items)
-        pages_fetched += 1
-
-        for item in batch:
-            yield item
-
-        # Up to the server's cap the requested per_page is honored, so a short
-        # page is the last one. Above the cap a short page is not conclusive
-        # and only an empty or shrinking page ends the iteration.
-        limit = per_page if per_page <= MAX_PER_PAGE else largest_batch
-        if not batch or len(batch) < limit:
-            return
-
-        largest_batch = max(largest_batch, len(batch))
-        page += 1
-
-
-def _paginate_cursor(method, kwargs, items, next_args, max_pages):
-    pages_fetched = 0
-    cursor_kwargs = {}
-
-    while max_pages is None or pages_fetched < max_pages:
-        response = method(**{**kwargs, **cursor_kwargs})
-        batch = _extract_items(response, items)
-        pages_fetched += 1
-
-        yield from batch
-
-        # Termination is delegated to next_args: empty pages keep iterating
-        # for as long as it keeps returning arguments for the next call
-        next_kwargs = next_args(response)
+        Termination is delegated to next_args: empty pages keep iterating
+        for as long as it keeps returning arguments for the next call. The
+        returned dict replaces the previous cursor arguments wholesale, so
+        cursor keys from earlier pages never leak into later requests.
+        """
+        next_kwargs = self.next_args(response)
         if not next_kwargs:
-            return
+            return False
 
-        # The returned dict replaces the previous cursor arguments wholesale,
-        # so cursor keys from earlier pages never leak into later requests
-        cursor_kwargs = next_kwargs
-
-
-async def _apaginate_cursor(method, kwargs, items, next_args, max_pages):
-    pages_fetched = 0
-    cursor_kwargs = {}
-
-    while max_pages is None or pages_fetched < max_pages:
-        response = await method(**{**kwargs, **cursor_kwargs})
-        batch = _extract_items(response, items)
-        pages_fetched += 1
-
-        for item in batch:
-            yield item
-
-        # Termination is delegated to next_args: empty pages keep iterating
-        # for as long as it keeps returning arguments for the next call
-        next_kwargs = next_args(response)
-        if not next_kwargs:
-            return
-
-        # The returned dict replaces the previous cursor arguments wholesale,
-        # so cursor keys from earlier pages never leak into later requests
-        cursor_kwargs = next_kwargs
+        self.cursor_kwargs = next_kwargs
+        return True
 
 
 def _validate(method, args, kwargs, items, next_args):
@@ -169,12 +158,6 @@ def _supports_offset_pagination(method):
         return True
 
     return "page" in parameters and "per_page" in parameters
-
-
-def _offset_start(kwargs, per_page):
-    page = kwargs.pop("page", None) or 0
-    # Default to the largest page size the server serves, not its default of 60
-    return page, per_page if per_page is not None else MAX_PER_PAGE
 
 
 def _cursor_per_page(method, per_page):

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -42,6 +42,7 @@ def apaginate(method, *args, per_page=None, items=None, next_args=None, max_page
 def _paginate_offset(method, args, kwargs, items, per_page, max_pages):
     page, per_page = _offset_start(kwargs, per_page)
     pages_fetched = 0
+    largest_batch = 0
 
     while max_pages is None or pages_fetched < max_pages:
         batch = _extract_items(method(*args, page=page, per_page=per_page, **kwargs), items)
@@ -49,15 +50,21 @@ def _paginate_offset(method, args, kwargs, items, per_page, max_pages):
 
         yield from batch
 
-        if len(batch) < per_page:
+        # Up to the server's cap the requested per_page is honored, so a short
+        # page is the last one. Above the cap a short page is not conclusive
+        # and only an empty or shrinking page ends the iteration.
+        limit = per_page if per_page <= MAX_PER_PAGE else largest_batch
+        if not batch or len(batch) < limit:
             return
 
+        largest_batch = max(largest_batch, len(batch))
         page += 1
 
 
 async def _apaginate_offset(method, args, kwargs, items, per_page, max_pages):
     page, per_page = _offset_start(kwargs, per_page)
     pages_fetched = 0
+    largest_batch = 0
 
     while max_pages is None or pages_fetched < max_pages:
         batch = _extract_items(await method(*args, page=page, per_page=per_page, **kwargs), items)
@@ -66,9 +73,14 @@ async def _apaginate_offset(method, args, kwargs, items, per_page, max_pages):
         for item in batch:
             yield item
 
-        if len(batch) < per_page:
+        # Up to the server's cap the requested per_page is honored, so a short
+        # page is the last one. Above the cap a short page is not conclusive
+        # and only an empty or shrinking page ends the iteration.
+        limit = per_page if per_page <= MAX_PER_PAGE else largest_batch
+        if not batch or len(batch) < limit:
             return
 
+        largest_batch = max(largest_batch, len(batch))
         page += 1
 
 

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -20,6 +20,7 @@ def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages
     _validate(method, items, next_args)
 
     if next_args is not None:
+        per_page = _cursor_per_page(method, per_page)
         if per_page is not None:
             kwargs["per_page"] = per_page
         return _paginate_cursor(method, args, kwargs, items, next_args, max_pages)
@@ -32,6 +33,7 @@ def apaginate(method, *args, per_page=None, items=None, next_args=None, max_page
     _validate(method, items, next_args)
 
     if next_args is not None:
+        per_page = _cursor_per_page(method, per_page)
         if per_page is not None:
             kwargs["per_page"] = per_page
         return _apaginate_cursor(method, args, kwargs, items, next_args, max_pages)
@@ -148,6 +150,20 @@ def _offset_start(kwargs, per_page):
     page = kwargs.pop("page", None) or 0
     # Default to the largest page size the server serves, not its default of 60
     return page, per_page if per_page is not None else MAX_PER_PAGE
+
+
+def _cursor_per_page(method, per_page):
+    if per_page is not None:
+        return per_page
+
+    # Default to the largest page size here as well, but only for methods
+    # that are known to accept per_page
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return None
+
+    return MAX_PER_PAGE if "per_page" in parameters else None
 
 
 def _extract_items(response, items):

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -13,28 +13,34 @@ import httpx
 from .constants import MAX_PER_PAGE
 
 
-def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+def paginate(
+    method, /, *args, per_page=None, items_from=None, next_params=None, max_pages=None, start_page=0, **kwargs
+):
     """Lazily yield every item of a paginated endpoint method.
 
     See :meth:`TypedDriver.paginate <mattermostautodriver.driver.driver.TypedDriver.paginate>`
     for parameter documentation.
     """
-    _validate(method, args, kwargs, items, next_args)
-    return _paginate_sync(method, _make_pager(method, kwargs, per_page, next_args), items, max_pages)
+    _validate(method, args, kwargs, items_from, next_params, start_page)
+    return _paginate_sync(method, _make_pager(method, kwargs, per_page, next_params, start_page), items_from, max_pages)
 
 
-def apaginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+def apaginate(
+    method, /, *args, per_page=None, items_from=None, next_params=None, max_pages=None, start_page=0, **kwargs
+):
     """Asynchronous variant of :func:`paginate` returning an async iterator."""
-    _validate(method, args, kwargs, items, next_args)
-    return _paginate_async(method, _make_pager(method, kwargs, per_page, next_args), items, max_pages)
+    _validate(method, args, kwargs, items_from, next_params, start_page)
+    return _paginate_async(
+        method, _make_pager(method, kwargs, per_page, next_params, start_page), items_from, max_pages
+    )
 
 
-def _paginate_sync(method, pager, items, max_pages):
+def _paginate_sync(method, pager, items_from, max_pages):
     pages_fetched = 0
 
     while max_pages is None or pages_fetched < max_pages:
         response = method(**pager.request_kwargs())
-        batch = _extract_items(response, items)
+        batch = _extract_items(response, items_from)
         pages_fetched += 1
 
         yield from batch
@@ -43,12 +49,12 @@ def _paginate_sync(method, pager, items, max_pages):
             return
 
 
-async def _paginate_async(method, pager, items, max_pages):
+async def _paginate_async(method, pager, items_from, max_pages):
     pages_fetched = 0
 
     while max_pages is None or pages_fetched < max_pages:
         response = await method(**pager.request_kwargs())
-        batch = _extract_items(response, items)
+        batch = _extract_items(response, items_from)
         pages_fetched += 1
 
         for item in batch:
@@ -58,18 +64,18 @@ async def _paginate_async(method, pager, items, max_pages):
             return
 
 
-def _make_pager(method, kwargs, per_page, next_args):
-    if next_args is not None:
-        return _CursorPager(kwargs, _cursor_per_page(method, per_page), next_args)
-    return _OffsetPager(kwargs, per_page)
+def _make_pager(method, kwargs, per_page, next_params, start_page):
+    if next_params is not None:
+        return _CursorPager(kwargs, _cursor_per_page(method, per_page), next_params)
+    return _OffsetPager(kwargs, per_page, start_page)
 
 
 class _OffsetPager:
     """Paging decisions for page/per_page based endpoints."""
 
-    def __init__(self, kwargs, per_page):
+    def __init__(self, kwargs, per_page, start_page):
         self.kwargs = kwargs
-        self.page = kwargs.pop("page", None) or 0
+        self.page = start_page
         # Default to the largest page size the server serves, not its default of 60
         self.per_page = per_page if per_page is not None else MAX_PER_PAGE
         self.largest_batch = 0
@@ -94,27 +100,27 @@ class _OffsetPager:
 
 
 class _CursorPager:
-    """Paging decisions for cursor based endpoints, driven by next_args."""
+    """Paging decisions for cursor based endpoints, driven by next_params."""
 
-    def __init__(self, kwargs, per_page, next_args):
+    def __init__(self, kwargs, per_page, next_params):
         self.kwargs = kwargs
         if per_page is not None:
             self.kwargs["per_page"] = per_page
         self.cursor_kwargs = {}
-        self.next_args = next_args
+        self.next_params = next_params
 
     def request_kwargs(self):
         return {**self.kwargs, **self.cursor_kwargs}
 
     def advance(self, response, batch):
-        """Advance to the next cursor, or return False when next_args stops.
+        """Advance to the next cursor, or return False when next_params stops.
 
-        Termination is delegated to next_args: empty pages keep iterating
-        for as long as it keeps returning arguments for the next call. The
-        returned dict replaces the previous cursor arguments wholesale, so
+        Termination is delegated to next_params: empty pages keep iterating
+        for as long as it keeps returning parameters for the next call. The
+        returned dict replaces the previous cursor parameters wholesale, so
         cursor keys from earlier pages never leak into later requests.
         """
-        next_kwargs = self.next_args(response)
+        next_kwargs = self.next_params(response)
         if not next_kwargs:
             return False
 
@@ -122,19 +128,22 @@ class _CursorPager:
         return True
 
 
-def _validate(method, args, kwargs, items, next_args):
-    if next_args is None and not _supports_offset_pagination(method):
+def _validate(method, args, kwargs, items_from, next_params, start_page):
+    if next_params is None and not _supports_offset_pagination(method):
         name = getattr(method, "__name__", repr(method))
         raise TypeError(
             f"{name}() does not accept 'page'/'per_page' and cannot be offset paginated. "
-            "Pass next_args= for cursor based endpoints, or call the method directly."
+            "Pass next_params= for cursor based endpoints, or call the method directly."
         )
 
-    if next_args is not None and "page" in kwargs:
+    if "page" in kwargs:
         raise TypeError(
-            "page= applies to offset pagination only and would be re-sent verbatim on "
-            "every request in cursor mode. Drive the paging via next_args instead."
+            "page= is not passed through by paginate(). Call the method directly for a "
+            "single page, or pass start_page= to begin iteration at a later page."
         )
+
+    if next_params is not None and start_page:
+        raise TypeError("start_page= applies to offset pagination only. Drive the paging via next_params instead.")
 
     if args:
         raise TypeError(
@@ -143,8 +152,8 @@ def _validate(method, args, kwargs, items, next_args):
             "cannot bind to page/per_page or the wrong query parameter."
         )
 
-    if items is not None and not (isinstance(items, str) or callable(items)):
-        raise TypeError("items= must be a response key (str) or a callable extracting a list from the response")
+    if items_from is not None and not (isinstance(items_from, str) or callable(items_from)):
+        raise TypeError("items_from= must be a response key (str) or a callable extracting a list from the response")
 
 
 def _supports_offset_pagination(method):
@@ -174,7 +183,7 @@ def _cursor_per_page(method, per_page):
     return MAX_PER_PAGE if "per_page" in parameters else None
 
 
-def _extract_items(response, items):
+def _extract_items(response, items_from):
     if isinstance(response, httpx.Response):
         content_type = response.headers.get("Content-Type", "unset")
         raise TypeError(
@@ -182,17 +191,19 @@ def _extract_items(response, items):
             f"status {response.status_code}) that cannot be paginated."
         )
 
-    if callable(items):
-        return list(items(response))
+    if callable(items_from):
+        return list(items_from(response))
 
-    if isinstance(items, str):
+    if isinstance(items_from, str):
         if not isinstance(response, dict):
-            raise TypeError(f"items={items!r} was given but the response is a {type(response).__name__}, not an object")
+            raise TypeError(
+                f"items_from={items_from!r} was given but the response is a {type(response).__name__}, not an object"
+            )
 
-        if items not in response:
-            raise KeyError(f"items={items!r} not found in the response. Available keys: {sorted(response)}")
+        if items_from not in response:
+            raise KeyError(f"items_from={items_from!r} not found in the response. Available keys: {sorted(response)}")
 
-        value = response[items]
+        value = response[items_from]
 
         if value is None:
             # Go servers serialize empty result slices as null
@@ -200,8 +211,8 @@ def _extract_items(response, items):
 
         if not isinstance(value, list):
             raise TypeError(
-                f"items={items!r} refers to a {type(value).__name__}, not a list. "
-                "Pass a callable as items= to extract the items instead."
+                f"items_from={items_from!r} refers to a {type(value).__name__}, not a list. "
+                "Pass a callable as items_from= to extract the items instead."
             )
 
         return value
@@ -210,6 +221,6 @@ def _extract_items(response, items):
         return response
 
     raise TypeError(
-        "Response is not a list. Pass items= (a response key or a callable) "
+        "Response is not a list. Pass items_from= (a response key or a callable) "
         "to tell paginate where to find the items in the response."
     )

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -43,9 +43,12 @@ def _paginate_sync(method, pager, items_from, max_pages):
         batch = _extract_items(response, items_from)
         pages_fetched += 1
 
+        # Advance before yielding, so a repeated page raises without its duplicate items being delivered
+        has_more = pager.advance(response, batch)
+
         yield from batch
 
-        if not pager.advance(response, batch):
+        if not has_more:
             return
 
 
@@ -57,28 +60,33 @@ async def _paginate_async(method, pager, items_from, max_pages):
         batch = _extract_items(response, items_from)
         pages_fetched += 1
 
+        # Advance before yielding, so a repeated page raises without its duplicate items being delivered
+        has_more = pager.advance(response, batch)
+
         for item in batch:
             yield item
 
-        if not pager.advance(response, batch):
+        if not has_more:
             return
 
 
 def _make_pager(method, kwargs, per_page, next_params, start_page):
     if next_params is not None:
         return _CursorPager(kwargs, _cursor_per_page(method, per_page), next_params)
-    return _OffsetPager(kwargs, per_page, start_page)
+    return _OffsetPager(method, kwargs, per_page, start_page)
 
 
 class _OffsetPager:
     """Paging decisions for page/per_page based endpoints."""
 
-    def __init__(self, kwargs, per_page, start_page):
+    def __init__(self, method, kwargs, per_page, start_page):
+        self.method_name = getattr(method, "__name__", repr(method))
         self.kwargs = kwargs
         self.page = start_page
         # Default to the largest page size the server serves, not its default of 60
         self.per_page = per_page if per_page is not None else MAX_PER_PAGE
         self.largest_batch = 0
+        self.previous_batch = None
 
     def request_kwargs(self):
         return {**self.kwargs, "page": self.page, "per_page": self.per_page}
@@ -89,11 +97,24 @@ class _OffsetPager:
         Up to the server's cap the requested per_page is honored, so a short
         page is the last one. Above the cap a short page is not conclusive
         and only an empty or shrinking page ends the iteration.
+
+        A page identical to the previous one means the server ignored
+        page/per_page — the iteration would repeat it forever, so raise instead.
         """
+        if batch == self.previous_batch:
+            raise RuntimeError(
+                f"{self.method_name}() returned an identical page twice in a row, so the server "
+                "appears to be ignoring page/per_page. Some endpoints only paginate when an "
+                "additional flag is set (e.g. paginate=True on group endpoints) and some stop "
+                "paginating for certain parameters (e.g. since= on posts.get_posts_for_channel). "
+                "Call the method directly instead."
+            )
+
         limit = self.per_page if self.per_page <= MAX_PER_PAGE else self.largest_batch
         if not batch or len(batch) < limit:
             return False
 
+        self.previous_batch = batch
         self.largest_batch = max(self.largest_batch, len(batch))
         self.page += 1
         return True

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -98,7 +98,9 @@ def _paginate_cursor(method, args, kwargs, items, next_args, max_pages):
 
         yield from batch
 
-        next_kwargs = next_args(response) if batch else None
+        # Termination is delegated to next_args: empty pages keep iterating
+        # for as long as it keeps returning arguments for the next call
+        next_kwargs = next_args(response)
         if not next_kwargs:
             return
 
@@ -116,7 +118,9 @@ async def _apaginate_cursor(method, args, kwargs, items, next_args, max_pages):
         for item in batch:
             yield item
 
-        next_kwargs = next_args(response) if batch else None
+        # Termination is delegated to next_args: empty pages keep iterating
+        # for as long as it keeps returning arguments for the next call
+        next_kwargs = next_args(response)
         if not next_kwargs:
             return
 

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -8,6 +8,8 @@ which are the documented entry points.
 
 import inspect
 
+import httpx
+
 from .constants import MAX_PER_PAGE
 
 
@@ -167,6 +169,13 @@ def _cursor_per_page(method, per_page):
 
 
 def _extract_items(response, items):
+    if isinstance(response, httpx.Response):
+        content_type = response.headers.get("Content-Type", "unset")
+        raise TypeError(
+            f"Server returned a non-JSON response (Content-Type {content_type!r}, "
+            f"status {response.status_code}) that cannot be paginated."
+        )
+
     if callable(items):
         return list(items(response))
 

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -19,7 +19,7 @@ def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages
     See :meth:`TypedDriver.paginate <mattermostautodriver.driver.driver.TypedDriver.paginate>`
     for parameter documentation.
     """
-    _validate(method, args, items, next_args)
+    _validate(method, args, kwargs, items, next_args)
 
     if next_args is not None:
         per_page = _cursor_per_page(method, per_page)
@@ -32,7 +32,7 @@ def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages
 
 def apaginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
     """Asynchronous variant of :func:`paginate` returning an async iterator."""
-    _validate(method, args, items, next_args)
+    _validate(method, args, kwargs, items, next_args)
 
     if next_args is not None:
         per_page = _cursor_per_page(method, per_page)
@@ -133,12 +133,18 @@ async def _apaginate_cursor(method, kwargs, items, next_args, max_pages):
         cursor_kwargs = next_kwargs
 
 
-def _validate(method, args, items, next_args):
+def _validate(method, args, kwargs, items, next_args):
     if next_args is None and not _supports_offset_pagination(method):
         name = getattr(method, "__name__", repr(method))
         raise TypeError(
             f"{name}() does not accept 'page'/'per_page' and cannot be offset paginated. "
             "Pass next_args= for cursor based endpoints, or call the method directly."
+        )
+
+    if next_args is not None and "page" in kwargs:
+        raise TypeError(
+            "page= applies to offset pagination only and would be re-sent verbatim on "
+            "every request in cursor mode. Drive the paging via next_args instead."
         )
 
     if args:

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -90,9 +90,10 @@ async def _apaginate_offset(method, kwargs, items, per_page, max_pages):
 
 def _paginate_cursor(method, kwargs, items, next_args, max_pages):
     pages_fetched = 0
+    cursor_kwargs = {}
 
     while max_pages is None or pages_fetched < max_pages:
-        response = method(**kwargs)
+        response = method(**{**kwargs, **cursor_kwargs})
         batch = _extract_items(response, items)
         pages_fetched += 1
 
@@ -104,14 +105,17 @@ def _paginate_cursor(method, kwargs, items, next_args, max_pages):
         if not next_kwargs:
             return
 
-        kwargs.update(next_kwargs)
+        # The returned dict replaces the previous cursor arguments wholesale,
+        # so cursor keys from earlier pages never leak into later requests
+        cursor_kwargs = next_kwargs
 
 
 async def _apaginate_cursor(method, kwargs, items, next_args, max_pages):
     pages_fetched = 0
+    cursor_kwargs = {}
 
     while max_pages is None or pages_fetched < max_pages:
-        response = await method(**kwargs)
+        response = await method(**{**kwargs, **cursor_kwargs})
         batch = _extract_items(response, items)
         pages_fetched += 1
 
@@ -124,7 +128,9 @@ async def _apaginate_cursor(method, kwargs, items, next_args, max_pages):
         if not next_kwargs:
             return
 
-        kwargs.update(next_kwargs)
+        # The returned dict replaces the previous cursor arguments wholesale,
+        # so cursor keys from earlier pages never leak into later requests
+        cursor_kwargs = next_kwargs
 
 
 def _validate(method, args, items, next_args):

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -184,7 +184,25 @@ def _extract_items(response, items):
         return list(items(response))
 
     if isinstance(items, str):
-        return response[items]
+        if not isinstance(response, dict):
+            raise TypeError(f"items={items!r} was given but the response is a {type(response).__name__}, not an object")
+
+        if items not in response:
+            raise KeyError(f"items={items!r} not found in the response. Available keys: {sorted(response)}")
+
+        value = response[items]
+
+        if value is None:
+            # Go servers serialize empty result slices as null
+            return []
+
+        if not isinstance(value, list):
+            raise TypeError(
+                f"items={items!r} refers to a {type(value).__name__}, not a list. "
+                "Pass a callable as items= to extract the items instead."
+            )
+
+        return value
 
     if isinstance(response, list):
         return response

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -1,0 +1,154 @@
+"""
+Helpers to lazily iterate over all items of paginated API endpoints.
+
+These implement :meth:`TypedDriver.paginate <mattermostautodriver.driver.driver.TypedDriver.paginate>`
+and :meth:`AsyncTypedDriver.paginate <mattermostautodriver.driver.driver.AsyncTypedDriver.paginate>`,
+which are the documented entry points.
+"""
+
+import inspect
+
+from .constants import MAX_PER_PAGE
+
+
+def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+    """Lazily yield every item of a paginated endpoint method.
+
+    See :meth:`TypedDriver.paginate <mattermostautodriver.driver.driver.TypedDriver.paginate>`
+    for parameter documentation.
+    """
+    _validate(method, items, next_args)
+
+    if next_args is not None:
+        if per_page is not None:
+            kwargs["per_page"] = per_page
+        return _paginate_cursor(method, args, kwargs, items, next_args, max_pages)
+
+    return _paginate_offset(method, args, kwargs, items, per_page, max_pages)
+
+
+def apaginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
+    """Asynchronous variant of :func:`paginate` returning an async iterator."""
+    _validate(method, items, next_args)
+
+    if next_args is not None:
+        if per_page is not None:
+            kwargs["per_page"] = per_page
+        return _apaginate_cursor(method, args, kwargs, items, next_args, max_pages)
+
+    return _apaginate_offset(method, args, kwargs, items, per_page, max_pages)
+
+
+def _paginate_offset(method, args, kwargs, items, per_page, max_pages):
+    page, per_page = _offset_start(kwargs, per_page)
+    pages_fetched = 0
+
+    while max_pages is None or pages_fetched < max_pages:
+        batch = _extract_items(method(*args, page=page, per_page=per_page, **kwargs), items)
+        pages_fetched += 1
+
+        yield from batch
+
+        if len(batch) < per_page:
+            return
+
+        page += 1
+
+
+async def _apaginate_offset(method, args, kwargs, items, per_page, max_pages):
+    page, per_page = _offset_start(kwargs, per_page)
+    pages_fetched = 0
+
+    while max_pages is None or pages_fetched < max_pages:
+        batch = _extract_items(await method(*args, page=page, per_page=per_page, **kwargs), items)
+        pages_fetched += 1
+
+        for item in batch:
+            yield item
+
+        if len(batch) < per_page:
+            return
+
+        page += 1
+
+
+def _paginate_cursor(method, args, kwargs, items, next_args, max_pages):
+    pages_fetched = 0
+
+    while max_pages is None or pages_fetched < max_pages:
+        response = method(*args, **kwargs)
+        batch = _extract_items(response, items)
+        pages_fetched += 1
+
+        yield from batch
+
+        next_kwargs = next_args(response) if batch else None
+        if not next_kwargs:
+            return
+
+        kwargs.update(next_kwargs)
+
+
+async def _apaginate_cursor(method, args, kwargs, items, next_args, max_pages):
+    pages_fetched = 0
+
+    while max_pages is None or pages_fetched < max_pages:
+        response = await method(*args, **kwargs)
+        batch = _extract_items(response, items)
+        pages_fetched += 1
+
+        for item in batch:
+            yield item
+
+        next_kwargs = next_args(response) if batch else None
+        if not next_kwargs:
+            return
+
+        kwargs.update(next_kwargs)
+
+
+def _validate(method, items, next_args):
+    if next_args is None and not _supports_offset_pagination(method):
+        name = getattr(method, "__name__", repr(method))
+        raise TypeError(
+            f"{name}() does not accept 'page'/'per_page' and cannot be offset paginated. "
+            "Pass next_args= for cursor based endpoints, or call the method directly."
+        )
+
+    if items is not None and not (isinstance(items, str) or callable(items)):
+        raise TypeError("items= must be a response key (str) or a callable extracting a list from the response")
+
+
+def _supports_offset_pagination(method):
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        # Signature cannot be introspected, assume the caller knows what they are doing
+        return True
+
+    if any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()):
+        return True
+
+    return "page" in parameters and "per_page" in parameters
+
+
+def _offset_start(kwargs, per_page):
+    page = kwargs.pop("page", None) or 0
+    # Default to the largest page size the server serves, not its default of 60
+    return page, per_page if per_page is not None else MAX_PER_PAGE
+
+
+def _extract_items(response, items):
+    if callable(items):
+        return list(items(response))
+
+    if isinstance(items, str):
+        return response[items]
+
+    if isinstance(response, list):
+        return response
+
+    raise TypeError(
+        "Response is not a list. Pass items= (a response key or a callable) "
+        "to tell paginate where to find the items in the response."
+    )

--- a/src/mattermostautodriver/pagination.py
+++ b/src/mattermostautodriver/pagination.py
@@ -19,37 +19,37 @@ def paginate(method, *args, per_page=None, items=None, next_args=None, max_pages
     See :meth:`TypedDriver.paginate <mattermostautodriver.driver.driver.TypedDriver.paginate>`
     for parameter documentation.
     """
-    _validate(method, items, next_args)
+    _validate(method, args, items, next_args)
 
     if next_args is not None:
         per_page = _cursor_per_page(method, per_page)
         if per_page is not None:
             kwargs["per_page"] = per_page
-        return _paginate_cursor(method, args, kwargs, items, next_args, max_pages)
+        return _paginate_cursor(method, kwargs, items, next_args, max_pages)
 
-    return _paginate_offset(method, args, kwargs, items, per_page, max_pages)
+    return _paginate_offset(method, kwargs, items, per_page, max_pages)
 
 
 def apaginate(method, *args, per_page=None, items=None, next_args=None, max_pages=None, **kwargs):
     """Asynchronous variant of :func:`paginate` returning an async iterator."""
-    _validate(method, items, next_args)
+    _validate(method, args, items, next_args)
 
     if next_args is not None:
         per_page = _cursor_per_page(method, per_page)
         if per_page is not None:
             kwargs["per_page"] = per_page
-        return _apaginate_cursor(method, args, kwargs, items, next_args, max_pages)
+        return _apaginate_cursor(method, kwargs, items, next_args, max_pages)
 
-    return _apaginate_offset(method, args, kwargs, items, per_page, max_pages)
+    return _apaginate_offset(method, kwargs, items, per_page, max_pages)
 
 
-def _paginate_offset(method, args, kwargs, items, per_page, max_pages):
+def _paginate_offset(method, kwargs, items, per_page, max_pages):
     page, per_page = _offset_start(kwargs, per_page)
     pages_fetched = 0
     largest_batch = 0
 
     while max_pages is None or pages_fetched < max_pages:
-        batch = _extract_items(method(*args, page=page, per_page=per_page, **kwargs), items)
+        batch = _extract_items(method(page=page, per_page=per_page, **kwargs), items)
         pages_fetched += 1
 
         yield from batch
@@ -65,13 +65,13 @@ def _paginate_offset(method, args, kwargs, items, per_page, max_pages):
         page += 1
 
 
-async def _apaginate_offset(method, args, kwargs, items, per_page, max_pages):
+async def _apaginate_offset(method, kwargs, items, per_page, max_pages):
     page, per_page = _offset_start(kwargs, per_page)
     pages_fetched = 0
     largest_batch = 0
 
     while max_pages is None or pages_fetched < max_pages:
-        batch = _extract_items(await method(*args, page=page, per_page=per_page, **kwargs), items)
+        batch = _extract_items(await method(page=page, per_page=per_page, **kwargs), items)
         pages_fetched += 1
 
         for item in batch:
@@ -88,11 +88,11 @@ async def _apaginate_offset(method, args, kwargs, items, per_page, max_pages):
         page += 1
 
 
-def _paginate_cursor(method, args, kwargs, items, next_args, max_pages):
+def _paginate_cursor(method, kwargs, items, next_args, max_pages):
     pages_fetched = 0
 
     while max_pages is None or pages_fetched < max_pages:
-        response = method(*args, **kwargs)
+        response = method(**kwargs)
         batch = _extract_items(response, items)
         pages_fetched += 1
 
@@ -107,11 +107,11 @@ def _paginate_cursor(method, args, kwargs, items, next_args, max_pages):
         kwargs.update(next_kwargs)
 
 
-async def _apaginate_cursor(method, args, kwargs, items, next_args, max_pages):
+async def _apaginate_cursor(method, kwargs, items, next_args, max_pages):
     pages_fetched = 0
 
     while max_pages is None or pages_fetched < max_pages:
-        response = await method(*args, **kwargs)
+        response = await method(**kwargs)
         batch = _extract_items(response, items)
         pages_fetched += 1
 
@@ -127,12 +127,19 @@ async def _apaginate_cursor(method, args, kwargs, items, next_args, max_pages):
         kwargs.update(next_kwargs)
 
 
-def _validate(method, items, next_args):
+def _validate(method, args, items, next_args):
     if next_args is None and not _supports_offset_pagination(method):
         name = getattr(method, "__name__", repr(method))
         raise TypeError(
             f"{name}() does not accept 'page'/'per_page' and cannot be offset paginated. "
             "Pass next_args= for cursor based endpoints, or call the method directly."
+        )
+
+    if args:
+        raise TypeError(
+            "paginate() passes only keyword arguments to the endpoint method. "
+            "Pass path parameters as keywords too, e.g. channel_id=..., so they "
+            "cannot bind to page/per_page or the wrong query parameter."
         )
 
     if items is not None and not (isinstance(items, str) or callable(items)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 from mattermostautodriver.client import AsyncClient, Client
+from mattermostautodriver.driver import AsyncTypedDriver, TypedDriver
 
 _BASE_OPTIONS = {
     "scheme": "http",
@@ -27,6 +28,14 @@ def make_client(handler, **extra_options):
 
 def make_async_client(handler, **extra_options):
     return AsyncClient(_client_options(handler, extra_options))
+
+
+def make_driver(handler, **extra_options):
+    return TypedDriver(_client_options(handler, extra_options))
+
+
+def make_async_driver(handler, **extra_options):
+    return AsyncTypedDriver(_client_options(handler, extra_options))
 
 
 def error_response(status, message="something failed", error_id="api.some.error", request_id="req1234"):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -219,6 +219,36 @@ def test_cursor_mode_merges_multiple_parameters():
     assert calls == [(None, None), ("u1", "alice")]
 
 
+def test_cursor_arguments_replace_rather_than_merge():
+    calls = []
+    responses = iter([[1], [2], [3]])
+
+    def method(after=None, before=None):
+        calls.append({"after": after, "before": before})
+        return next(responses)
+
+    steps = iter([{"after": "a1"}, {"before": "b1"}, None])
+    assert list(paginate(method, next_args=lambda r: next(steps))) == [1, 2, 3]
+
+    # Switching cursor keys mid-walk must not leak the stale key
+    assert calls == [
+        {"after": None, "before": None},
+        {"after": "a1", "before": None},
+        {"after": None, "before": "b1"},
+    ]
+
+
+def test_cursor_arguments_override_a_starting_cursor():
+    calls = []
+
+    def method(before=None):
+        calls.append(before)
+        return [1] if before == "start" else []
+
+    assert list(paginate(method, before="start", next_args=lambda r: {"before": "b2"} if r else None)) == [1]
+    assert calls == ["start", "b2"]
+
+
 def test_cursor_mode_consults_next_args_even_for_pages_without_items():
     pages = {
         None: {"items": [1], "next": "a"},

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -123,6 +123,38 @@ def test_dict_response_without_items_raises():
         list(paginate(method))
 
 
+def test_items_key_with_null_value_is_treated_as_an_empty_page():
+    def method(page=0, per_page=60):
+        # Go servers serialize empty result slices as null
+        return {"threads": None, "total": 0}
+
+    assert list(paginate(method, items="threads")) == []
+
+
+def test_items_key_missing_from_response_names_the_available_keys():
+    def method(page=0, per_page=60):
+        return {"threads": [], "total": 0}
+
+    with pytest.raises(KeyError, match="'thread'.*Available keys.*threads"):
+        list(paginate(method, items="thread"))
+
+
+def test_items_key_pointing_at_a_non_list_raises():
+    def method(page=0, per_page=60):
+        return {"order": ["a"], "posts": {"a": {"id": "a"}}}
+
+    with pytest.raises(TypeError, match="'posts' refers to a dict"):
+        list(paginate(method, items="posts"))
+
+
+def test_items_key_with_a_list_response_raises():
+    def method(page=0, per_page=60):
+        return [{"id": "u1"}]
+
+    with pytest.raises(TypeError, match="response is a list"):
+        list(paginate(method, items="threads"))
+
+
 def test_invalid_items_raises_before_any_call():
     method, calls = make_offset_method([[1]])
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,268 @@
+import itertools
+
+import httpx
+import pytest
+
+from mattermostautodriver.driver import AsyncTypedDriver, TypedDriver
+from mattermostautodriver.pagination import apaginate, paginate
+
+_DRIVER_OPTIONS = {
+    "scheme": "http",
+    "url": "localhost",
+    "port": 8065,
+    "max_retries": 0,
+}
+
+
+def make_offset_method(pages):
+    """Fake endpoint method serving ``pages[page]`` and recording each call."""
+    calls = []
+
+    def method(page=0, per_page=60, **kwargs):
+        calls.append({"page": page, "per_page": per_page, **kwargs})
+        return pages[page] if page < len(pages) else []
+
+    return method, calls
+
+
+def test_iterates_across_pages_and_stops_on_short_page():
+    method, calls = make_offset_method([[1, 2], [3, 4], [5]])
+
+    assert list(paginate(method, per_page=2)) == [1, 2, 3, 4, 5]
+    assert [call["page"] for call in calls] == [0, 1, 2]
+    assert all(call["per_page"] == 2 for call in calls)
+
+
+def test_stops_on_empty_first_page():
+    method, calls = make_offset_method([[]])
+
+    assert list(paginate(method, per_page=2)) == []
+    assert len(calls) == 1
+
+
+def test_full_last_page_is_followed_by_one_empty_request():
+    method, calls = make_offset_method([[1, 2]])
+
+    assert list(paginate(method, per_page=2)) == [1, 2]
+    assert len(calls) == 2
+
+
+def test_pages_are_fetched_lazily():
+    method, calls = make_offset_method([[1, 2], [3, 4], [5]])
+
+    iterator = paginate(method, per_page=2)
+    assert calls == []
+
+    assert list(itertools.islice(iterator, 2)) == [1, 2]
+    assert len(calls) == 1
+
+
+def test_extra_arguments_are_passed_through():
+    method, calls = make_offset_method([[1]])
+
+    list(paginate(method, per_page=2, in_team="team_id"))
+    assert calls[0]["in_team"] == "team_id"
+
+
+def test_page_argument_sets_the_starting_page():
+    method, calls = make_offset_method([[1, 2], [3, 4], [5]])
+
+    assert list(paginate(method, page=2, per_page=2)) == [5]
+    assert [call["page"] for call in calls] == [2]
+
+
+def test_max_pages_limits_requests():
+    method, calls = make_offset_method([[1, 2], [3, 4], [5, 6], [7, 8]])
+
+    assert list(paginate(method, per_page=2, max_pages=2)) == [1, 2, 3, 4]
+    assert len(calls) == 2
+
+
+def test_items_as_key_unwraps_dict_responses():
+    def method(page=0, per_page=60):
+        return {"threads": [1, 2] if page == 0 else [3], "total": 3}
+
+    assert list(paginate(method, per_page=2, items="threads")) == [1, 2, 3]
+
+
+def test_items_as_callable_unwraps_dict_responses():
+    def method(page=0, per_page=60):
+        return {"order": ["a"], "posts": {"a": {"id": "a"}}} if page == 0 else {"order": [], "posts": {}}
+
+    result = list(paginate(method, per_page=2, items=lambda r: [r["posts"][pid] for pid in r["order"]]))
+    assert result == [{"id": "a"}]
+
+
+def test_dict_response_without_items_raises():
+    def method(page=0, per_page=60):
+        return {"threads": []}
+
+    with pytest.raises(TypeError, match="items="):
+        list(paginate(method))
+
+
+def test_invalid_items_raises_before_any_call():
+    method, calls = make_offset_method([[1]])
+
+    with pytest.raises(TypeError, match="items="):
+        paginate(method, items=42)
+    assert calls == []
+
+
+def test_method_without_page_arguments_raises_before_any_call():
+    calls = []
+
+    def not_paginated(user_id):
+        calls.append(user_id)
+
+    with pytest.raises(TypeError, match="does not accept 'page'/'per_page'"):
+        paginate(not_paginated, "me")
+    assert calls == []
+
+
+def test_cursor_mode_follows_next_args():
+    pages = {None: [1, 2], 2: [3, 4], 4: []}
+    calls = []
+
+    def method(after=None):
+        calls.append(after)
+        return pages[after]
+
+    result = list(paginate(method, next_args=lambda r: {"after": r[-1]} if r else None))
+    assert result == [1, 2, 3, 4]
+    assert calls == [None, 2, 4]
+
+
+def test_cursor_mode_stops_when_next_args_returns_none():
+    def method(after=None):
+        return [1]
+
+    assert list(paginate(method, next_args=lambda r: None)) == [1]
+
+
+def test_cursor_mode_merges_multiple_parameters():
+    calls = []
+
+    def method(from_id=None, from_column_value=None):
+        calls.append((from_id, from_column_value))
+        return [{"id": "u1", "username": "alice"}] if from_id is None else []
+
+    next_args = lambda r: {"from_id": r[-1]["id"], "from_column_value": r[-1]["username"]}
+    assert len(list(paginate(method, next_args=next_args))) == 1
+    assert calls == [(None, None), ("u1", "alice")]
+
+
+def test_cursor_mode_forwards_explicit_per_page():
+    calls = []
+
+    def method(per_page=60, before=None):
+        calls.append(per_page)
+        return []
+
+    list(paginate(method, per_page=5, next_args=lambda r: None))
+    assert calls == [5]
+
+
+async def test_apaginate_iterates_across_pages():
+    pages = [[1, 2], [3]]
+    calls = []
+
+    async def method(page=0, per_page=60):
+        calls.append(page)
+        return pages[page] if page < len(pages) else []
+
+    assert [item async for item in apaginate(method, per_page=2)] == [1, 2, 3]
+    assert calls == [0, 1]
+
+
+async def test_apaginate_validates_before_any_call():
+    async def not_paginated(user_id):
+        pass  # pragma: no cover
+
+    with pytest.raises(TypeError, match="does not accept 'page'/'per_page'"):
+        apaginate(not_paginated, "me")
+
+
+async def test_apaginate_cursor_mode():
+    pages = {None: [1, 2], 2: []}
+
+    async def method(after=None):
+        return pages[after]
+
+    result = [item async for item in apaginate(method, next_args=lambda r: {"after": r[-1]} if r else None)]
+    assert result == [1, 2]
+
+
+# Integration tests through the drivers and real endpoint methods
+
+
+def make_users_handler(users):
+    """MockTransport handler serving ``users`` through /api/v4/users pagination."""
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        page = int(request.url.params.get("page", 0))
+        per_page = int(request.url.params.get("per_page", 60))
+        return httpx.Response(200, json=users[page * per_page : (page + 1) * per_page])
+
+    return handler, requests
+
+
+def test_driver_paginate_users():
+    users = [{"id": f"user{i}"} for i in range(5)]
+    handler, requests = make_users_handler(users)
+    driver = TypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+
+    assert list(driver.paginate(driver.users.get_users, per_page=2)) == users
+    assert [request.url.params["page"] for request in requests] == ["0", "1", "2"]
+
+
+def test_driver_paginate_is_lazy():
+    users = [{"id": f"user{i}"} for i in range(5)]
+    handler, requests = make_users_handler(users)
+    driver = TypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+
+    iterator = driver.paginate(driver.users.get_users, per_page=2)
+    assert requests == []
+
+    next(iterator)
+    assert len(requests) == 1
+
+
+async def test_async_driver_paginate_users():
+    users = [{"id": f"user{i}"} for i in range(3)]
+    handler, requests = make_users_handler(users)
+    driver = AsyncTypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+
+    result = [user async for user in driver.paginate(driver.users.get_users, per_page=2)]
+    assert result == users
+    assert [request.url.params["page"] for request in requests] == ["0", "1"]
+
+
+async def test_async_driver_paginate_posts_with_cursor():
+    # Two pages of channel posts in reverse chronological order, linked by prev_post_id
+    pages = {
+        None: {"order": ["p4", "p3"], "posts": {"p4": {"id": "p4"}, "p3": {"id": "p3"}}, "prev_post_id": "p2"},
+        "p3": {"order": ["p2", "p1"], "posts": {"p2": {"id": "p2"}, "p1": {"id": "p1"}}, "prev_post_id": ""},
+    }
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, json=pages[request.url.params.get("before")])
+
+    driver = AsyncTypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+
+    posts = [
+        post
+        async for post in driver.paginate(
+            driver.posts.get_posts_for_channel,
+            "channel_id",
+            items=lambda r: [r["posts"][pid] for pid in r["order"]],
+            next_args=lambda r: {"before": r["order"][-1]} if r["prev_post_id"] else None,
+        )
+    ]
+
+    assert [post["id"] for post in posts] == ["p4", "p3", "p2", "p1"]
+    assert [request.url.params.get("before") for request in requests] == [None, "p3"]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -94,6 +94,40 @@ def test_untrusted_per_page_confirms_a_short_first_page_with_an_empty_request():
     assert [call["page"] for call in calls] == [0, 1]
 
 
+def test_identical_pages_raise_instead_of_looping_forever():
+    # e.g. groups endpoints without paginate=True, or posts with since=,
+    # serve the identical full result set for every page
+    calls = []
+
+    def method(page=0, per_page=60):
+        calls.append(page)
+        return [1, 2]
+
+    collected = []
+    with pytest.raises(RuntimeError, match=r"method\(\) returned an identical page"):
+        for item in paginate(method, per_page=2):
+            collected.append(item)
+
+    # The repeated page is detected before its duplicate items are yielded
+    assert collected == [1, 2]
+    assert calls == [0, 1]
+
+
+def test_identical_pages_raise_with_an_untrusted_per_page():
+    def method(page=0, per_page=60):
+        return [1, 2]
+
+    with pytest.raises(RuntimeError, match="identical page"):
+        list(paginate(method, per_page=300))
+
+
+def test_identical_short_pages_still_end_the_iteration():
+    method, calls = make_offset_method([[1, 2], [1, 2]])
+
+    assert list(paginate(method, per_page=3)) == [1, 2]
+    assert len(calls) == 1
+
+
 def test_max_pages_limits_requests():
     method, calls = make_offset_method([[1, 2], [3, 4], [5, 6], [7, 8]])
 
@@ -276,7 +310,9 @@ def test_cursor_mode_consults_next_params_even_for_pages_without_items():
         calls.append(after)
         return pages[after]
 
-    result = list(paginate(method, items_from="items", next_params=lambda r: {"after": r["next"]} if r["next"] else None))
+    result = list(
+        paginate(method, items_from="items", next_params=lambda r: {"after": r["next"]} if r["next"] else None)
+    )
     assert result == [1, 2]
     assert calls == [None, "a", "b"]
 
@@ -332,6 +368,14 @@ async def test_apaginate_iterates_across_pages():
 
     assert [item async for item in apaginate(method, per_page=2)] == [1, 2, 3]
     assert calls == [0, 1]
+
+
+async def test_apaginate_identical_pages_raise():
+    async def method(page=0, per_page=60):
+        return [1, 2]
+
+    with pytest.raises(RuntimeError, match="identical page"):
+        [item async for item in apaginate(method, per_page=2)]
 
 
 async def test_apaginate_validates_before_any_call():

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -219,6 +219,18 @@ def test_cursor_mode_merges_multiple_parameters():
     assert calls == [(None, None), ("u1", "alice")]
 
 
+def test_page_argument_in_cursor_mode_raises_before_any_call():
+    calls = []
+
+    def method(page=0, per_page=60, before=None):
+        calls.append(page)
+        return []
+
+    with pytest.raises(TypeError, match="page= applies to offset pagination"):
+        paginate(method, page=2, next_args=lambda r: None)
+    assert calls == []
+
+
 def test_cursor_arguments_replace_rather_than_merge():
     calls = []
     responses = iter([[1], [2], [3]])

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -57,11 +57,19 @@ def test_extra_arguments_are_passed_through():
     assert calls[0]["in_team"] == "team_id"
 
 
-def test_page_argument_sets_the_starting_page():
+def test_start_page_sets_the_starting_page():
     method, calls = make_offset_method([[1, 2], [3, 4], [5]])
 
-    assert list(paginate(method, page=2, per_page=2)) == [5]
+    assert list(paginate(method, start_page=2, per_page=2)) == [5]
     assert [call["page"] for call in calls] == [2]
+
+
+def test_page_argument_raises_before_any_call():
+    method, calls = make_offset_method([[1, 2]])
+
+    with pytest.raises(TypeError, match="page= is not passed through"):
+        paginate(method, page=2)
+    assert calls == []
 
 
 def test_server_capping_per_page_does_not_end_iteration_early():
@@ -97,14 +105,14 @@ def test_items_as_key_unwraps_dict_responses():
     def method(page=0, per_page=60):
         return {"threads": [1, 2] if page == 0 else [3], "total": 3}
 
-    assert list(paginate(method, per_page=2, items="threads")) == [1, 2, 3]
+    assert list(paginate(method, per_page=2, items_from="threads")) == [1, 2, 3]
 
 
 def test_items_as_callable_unwraps_dict_responses():
     def method(page=0, per_page=60):
         return {"order": ["a"], "posts": {"a": {"id": "a"}}} if page == 0 else {"order": [], "posts": {}}
 
-    result = list(paginate(method, per_page=2, items=lambda r: [r["posts"][pid] for pid in r["order"]]))
+    result = list(paginate(method, per_page=2, items_from=lambda r: [r["posts"][pid] for pid in r["order"]]))
     assert result == [{"id": "a"}]
 
 
@@ -112,7 +120,7 @@ def test_dict_response_without_items_raises():
     def method(page=0, per_page=60):
         return {"threads": []}
 
-    with pytest.raises(TypeError, match="items="):
+    with pytest.raises(TypeError, match="items_from="):
         list(paginate(method))
 
 
@@ -121,7 +129,7 @@ def test_items_key_with_null_value_is_treated_as_an_empty_page():
         # Go servers serialize empty result slices as null
         return {"threads": None, "total": 0}
 
-    assert list(paginate(method, items="threads")) == []
+    assert list(paginate(method, items_from="threads")) == []
 
 
 def test_items_key_missing_from_response_names_the_available_keys():
@@ -129,7 +137,7 @@ def test_items_key_missing_from_response_names_the_available_keys():
         return {"threads": [], "total": 0}
 
     with pytest.raises(KeyError, match="'thread'.*Available keys.*threads"):
-        list(paginate(method, items="thread"))
+        list(paginate(method, items_from="thread"))
 
 
 def test_items_key_pointing_at_a_non_list_raises():
@@ -137,7 +145,7 @@ def test_items_key_pointing_at_a_non_list_raises():
         return {"order": ["a"], "posts": {"a": {"id": "a"}}}
 
     with pytest.raises(TypeError, match="'posts' refers to a dict"):
-        list(paginate(method, items="posts"))
+        list(paginate(method, items_from="posts"))
 
 
 def test_items_key_with_a_list_response_raises():
@@ -145,14 +153,14 @@ def test_items_key_with_a_list_response_raises():
         return [{"id": "u1"}]
 
     with pytest.raises(TypeError, match="response is a list"):
-        list(paginate(method, items="threads"))
+        list(paginate(method, items_from="threads"))
 
 
 def test_invalid_items_raises_before_any_call():
     method, calls = make_offset_method([[1]])
 
-    with pytest.raises(TypeError, match="items="):
-        paginate(method, items=42)
+    with pytest.raises(TypeError, match="items_from="):
+        paginate(method, items_from=42)
     assert calls == []
 
 
@@ -176,11 +184,11 @@ def test_positional_arguments_raise_before_any_call():
     with pytest.raises(TypeError, match="only keyword arguments"):
         paginate(method, "cid")
     with pytest.raises(TypeError, match="only keyword arguments"):
-        paginate(method, "cid", next_args=lambda r: None)
+        paginate(method, "cid", next_params=lambda r: None)
     assert calls == []
 
 
-def test_cursor_mode_follows_next_args():
+def test_cursor_mode_follows_next_params():
     pages = {None: [1, 2], 2: [3, 4], 4: []}
     calls = []
 
@@ -188,16 +196,16 @@ def test_cursor_mode_follows_next_args():
         calls.append(after)
         return pages[after]
 
-    result = list(paginate(method, next_args=lambda r: {"after": r[-1]} if r else None))
+    result = list(paginate(method, next_params=lambda r: {"after": r[-1]} if r else None))
     assert result == [1, 2, 3, 4]
     assert calls == [None, 2, 4]
 
 
-def test_cursor_mode_stops_when_next_args_returns_none():
+def test_cursor_mode_stops_when_next_params_returns_none():
     def method(after=None):
         return [1]
 
-    assert list(paginate(method, next_args=lambda r: None)) == [1]
+    assert list(paginate(method, next_params=lambda r: None)) == [1]
 
 
 def test_cursor_mode_merges_multiple_parameters():
@@ -207,8 +215,8 @@ def test_cursor_mode_merges_multiple_parameters():
         calls.append((from_id, from_column_value))
         return [{"id": "u1", "username": "alice"}] if from_id is None else []
 
-    next_args = lambda r: {"from_id": r[-1]["id"], "from_column_value": r[-1]["username"]} if r else None
-    assert len(list(paginate(method, next_args=next_args))) == 1
+    next_params = lambda r: {"from_id": r[-1]["id"], "from_column_value": r[-1]["username"]} if r else None
+    assert len(list(paginate(method, next_params=next_params))) == 1
     assert calls == [(None, None), ("u1", "alice")]
 
 
@@ -219,8 +227,10 @@ def test_page_argument_in_cursor_mode_raises_before_any_call():
         calls.append(page)
         return []
 
-    with pytest.raises(TypeError, match="page= applies to offset pagination"):
-        paginate(method, page=2, next_args=lambda r: None)
+    with pytest.raises(TypeError, match="page= is not passed through"):
+        paginate(method, page=2, next_params=lambda r: None)
+    with pytest.raises(TypeError, match="start_page= applies to offset pagination"):
+        paginate(method, start_page=2, next_params=lambda r: None)
     assert calls == []
 
 
@@ -233,7 +243,7 @@ def test_cursor_arguments_replace_rather_than_merge():
         return next(responses)
 
     steps = iter([{"after": "a1"}, {"before": "b1"}, None])
-    assert list(paginate(method, next_args=lambda r: next(steps))) == [1, 2, 3]
+    assert list(paginate(method, next_params=lambda r: next(steps))) == [1, 2, 3]
 
     # Switching cursor keys mid-walk must not leak the stale key
     assert calls == [
@@ -250,11 +260,11 @@ def test_cursor_arguments_override_a_starting_cursor():
         calls.append(before)
         return [1] if before == "start" else []
 
-    assert list(paginate(method, before="start", next_args=lambda r: {"before": "b2"} if r else None)) == [1]
+    assert list(paginate(method, before="start", next_params=lambda r: {"before": "b2"} if r else None)) == [1]
     assert calls == ["start", "b2"]
 
 
-def test_cursor_mode_consults_next_args_even_for_pages_without_items():
+def test_cursor_mode_consults_next_params_even_for_pages_without_items():
     pages = {
         None: {"items": [1], "next": "a"},
         "a": {"items": [], "next": "b"},
@@ -266,7 +276,7 @@ def test_cursor_mode_consults_next_args_even_for_pages_without_items():
         calls.append(after)
         return pages[after]
 
-    result = list(paginate(method, items="items", next_args=lambda r: {"after": r["next"]} if r["next"] else None))
+    result = list(paginate(method, items_from="items", next_params=lambda r: {"after": r["next"]} if r["next"] else None))
     assert result == [1, 2]
     assert calls == [None, "a", "b"]
 
@@ -278,7 +288,7 @@ def test_cursor_mode_defaults_per_page_when_method_accepts_it():
         calls.append(per_page)
         return []
 
-    list(paginate(method, next_args=lambda r: None))
+    list(paginate(method, next_params=lambda r: None))
     assert calls == [200]
 
 
@@ -289,7 +299,7 @@ def test_cursor_mode_omits_per_page_when_method_does_not_accept_it():
         calls.append(before)
         return []
 
-    list(paginate(method, next_args=lambda r: None))
+    list(paginate(method, next_params=lambda r: None))
     assert calls == [None]
 
 
@@ -308,7 +318,7 @@ def test_cursor_mode_forwards_explicit_per_page():
         calls.append(per_page)
         return []
 
-    list(paginate(method, per_page=5, next_args=lambda r: None))
+    list(paginate(method, per_page=5, next_params=lambda r: None))
     assert calls == [5]
 
 
@@ -338,7 +348,7 @@ async def test_apaginate_cursor_mode():
     async def method(after=None):
         return pages[after]
 
-    result = [item async for item in apaginate(method, next_args=lambda r: {"after": r[-1]} if r else None)]
+    result = [item async for item in apaginate(method, next_params=lambda r: {"after": r[-1]} if r else None)]
     assert result == [1, 2]
 
 
@@ -408,8 +418,8 @@ async def test_async_driver_paginate_posts_with_cursor():
         async for post in driver.paginate(
             driver.posts.get_posts_for_channel,
             channel_id="channel_id",
-            items=lambda r: [r["posts"][pid] for pid in r["order"]],
-            next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
+            items_from=lambda r: [r["posts"][pid] for pid in r["order"]],
+            next_params=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
         )
     ]
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -71,6 +71,28 @@ def test_page_argument_sets_the_starting_page():
     assert [call["page"] for call in calls] == [2]
 
 
+def test_server_capping_per_page_does_not_end_iteration_early():
+    # per_page above the server maximum (200) is silently capped by the
+    # server, so a page smaller than per_page must not end the iteration
+    server_cap = 2
+    pages = [[1, 2], [3, 4], [5]]
+    calls = []
+
+    def method(page=0, per_page=60):
+        calls.append(per_page)
+        return pages[page][:server_cap] if page < len(pages) else []
+
+    assert list(paginate(method, per_page=300)) == [1, 2, 3, 4, 5]
+    assert calls == [300, 300, 300]
+
+
+def test_untrusted_per_page_confirms_a_short_first_page_with_an_empty_request():
+    method, calls = make_offset_method([[1]])
+
+    assert list(paginate(method, per_page=300)) == [1]
+    assert [call["page"] for call in calls] == [0, 1]
+
+
 def test_max_pages_limits_requests():
     method, calls = make_offset_method([[1, 2], [3, 4], [5, 6], [7, 8]])
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -196,6 +196,14 @@ def test_cursor_mode_omits_per_page_when_method_does_not_accept_it():
     assert calls == [None]
 
 
+def test_raw_response_gives_a_helpful_error():
+    def method(page=0, per_page=60):
+        return httpx.Response(200, text="<html>maintenance</html>", headers={"Content-Type": "text/html"})
+
+    with pytest.raises(TypeError, match="non-JSON response"):
+        list(paginate(method))
+
+
 def test_cursor_mode_forwards_explicit_per_page():
     calls = []
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -3,15 +3,8 @@ import itertools
 import httpx
 import pytest
 
-from mattermostautodriver.driver import AsyncTypedDriver, TypedDriver
+from conftest import make_async_driver, make_driver
 from mattermostautodriver.pagination import apaginate, paginate
-
-_DRIVER_OPTIONS = {
-    "scheme": "http",
-    "url": "localhost",
-    "port": 8065,
-    "max_retries": 0,
-}
 
 
 def make_offset_method(pages):
@@ -368,7 +361,7 @@ def make_users_handler(users):
 def test_driver_paginate_users():
     users = [{"id": f"user{i}"} for i in range(5)]
     handler, requests = make_users_handler(users)
-    driver = TypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+    driver = make_driver(handler)
 
     assert list(driver.paginate(driver.users.get_users, per_page=2)) == users
     assert [request.url.params["page"] for request in requests] == ["0", "1", "2"]
@@ -377,7 +370,7 @@ def test_driver_paginate_users():
 def test_driver_paginate_is_lazy():
     users = [{"id": f"user{i}"} for i in range(5)]
     handler, requests = make_users_handler(users)
-    driver = TypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+    driver = make_driver(handler)
 
     iterator = driver.paginate(driver.users.get_users, per_page=2)
     assert requests == []
@@ -389,7 +382,7 @@ def test_driver_paginate_is_lazy():
 async def test_async_driver_paginate_users():
     users = [{"id": f"user{i}"} for i in range(3)]
     handler, requests = make_users_handler(users)
-    driver = AsyncTypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+    driver = make_async_driver(handler)
 
     result = [user async for user in driver.paginate(driver.users.get_users, per_page=2)]
     assert result == users
@@ -408,7 +401,7 @@ async def test_async_driver_paginate_posts_with_cursor():
         requests.append(request)
         return httpx.Response(200, json=pages[request.url.params.get("before")])
 
-    driver = AsyncTypedDriver({**_DRIVER_OPTIONS, "transport": httpx.MockTransport(handler)})
+    driver = make_async_driver(handler)
 
     posts = [
         post

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -174,6 +174,28 @@ def test_cursor_mode_merges_multiple_parameters():
     assert calls == [(None, None), ("u1", "alice")]
 
 
+def test_cursor_mode_defaults_per_page_when_method_accepts_it():
+    calls = []
+
+    def method(per_page=60, before=None):
+        calls.append(per_page)
+        return []
+
+    list(paginate(method, next_args=lambda r: None))
+    assert calls == [200]
+
+
+def test_cursor_mode_omits_per_page_when_method_does_not_accept_it():
+    calls = []
+
+    def method(before=None):
+        calls.append(before)
+        return []
+
+    list(paginate(method, next_args=lambda r: None))
+    assert calls == [None]
+
+
 def test_cursor_mode_forwards_explicit_per_page():
     calls = []
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -169,9 +169,26 @@ def test_cursor_mode_merges_multiple_parameters():
         calls.append((from_id, from_column_value))
         return [{"id": "u1", "username": "alice"}] if from_id is None else []
 
-    next_args = lambda r: {"from_id": r[-1]["id"], "from_column_value": r[-1]["username"]}
+    next_args = lambda r: {"from_id": r[-1]["id"], "from_column_value": r[-1]["username"]} if r else None
     assert len(list(paginate(method, next_args=next_args))) == 1
     assert calls == [(None, None), ("u1", "alice")]
+
+
+def test_cursor_mode_consults_next_args_even_for_pages_without_items():
+    pages = {
+        None: {"items": [1], "next": "a"},
+        "a": {"items": [], "next": "b"},
+        "b": {"items": [2], "next": None},
+    }
+    calls = []
+
+    def method(after=None):
+        calls.append(after)
+        return pages[after]
+
+    result = list(paginate(method, items="items", next_args=lambda r: {"after": r["next"]} if r["next"] else None))
+    assert result == [1, 2]
+    assert calls == [None, "a", "b"]
 
 
 def test_cursor_mode_defaults_per_page_when_method_accepts_it():
@@ -312,7 +329,7 @@ async def test_async_driver_paginate_posts_with_cursor():
             driver.posts.get_posts_for_channel,
             "channel_id",
             items=lambda r: [r["posts"][pid] for pid in r["order"]],
-            next_args=lambda r: {"before": r["order"][-1]} if r["prev_post_id"] else None,
+            next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
         )
     ]
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -174,6 +174,19 @@ def test_method_without_page_arguments_raises_before_any_call():
     assert calls == []
 
 
+def test_positional_arguments_raise_before_any_call():
+    calls = []
+
+    def method(channel_id=None, page=0, per_page=60):
+        calls.append(channel_id)
+
+    with pytest.raises(TypeError, match="only keyword arguments"):
+        paginate(method, "cid")
+    with pytest.raises(TypeError, match="only keyword arguments"):
+        paginate(method, "cid", next_args=lambda r: None)
+    assert calls == []
+
+
 def test_cursor_mode_follows_next_args():
     pages = {None: [1, 2], 2: [3, 4], 4: []}
     calls = []
@@ -359,7 +372,7 @@ async def test_async_driver_paginate_posts_with_cursor():
         post
         async for post in driver.paginate(
             driver.posts.get_posts_for_channel,
-            "channel_id",
+            channel_id="channel_id",
             items=lambda r: [r["posts"][pid] for pid in r["order"]],
             next_args=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
         )


### PR DESCRIPTION
Adds a pagination helper to `TypedDriver` and `AsyncTypedDriver`, so callers no
longer hand-roll `page`/`per_page` loops. Pages are fetched lazily as iteration
progresses, and all endpoint parameters are passed as keywords.

## Offset endpoints (~49 methods with `page`/`per_page`)

Fully automatic — `per_page` defaults to the server maximum (200), and iteration
stops on a short page. Requested sizes above 200 are untrusted (the server
silently caps them), so there only an empty or shrinking page ends iteration.

```python
for user in driver.paginate(driver.users.get_users, in_team=team_id):
    print(user["username"])

# start_page= skips ahead; max_pages= caps the number of requests
for team in driver.paginate(driver.teams.get_all_teams, start_page=2, max_pages=5):
    ...
```

## Wrapped responses

When the endpoint wraps the item list in an object, `items_from=` (a response
key or a callable) says where the items live:

```python
for thread in driver.paginate(
    driver.threads.get_user_threads, user_id=user_id, team_id=team_id,
    items_from="threads",
):
    ...
```

## Cursor endpoints

For endpoints paginating with cursors (posts `before`/`after`, reporting
keysets), `next_params=` receives each response and returns the parameters for
the next call — `None` stops. Walking a channel's full post history:

```python
for post in driver.paginate(
    driver.posts.get_posts_for_channel,
    channel_id=channel_id,
    items_from=lambda r: [r["posts"][pid] for pid in r["order"]],
    next_params=lambda r: {"before": r["order"][-1]} if r["order"] and r["prev_post_id"] else None,
):
    ...
```

## Async

Same spelling on `AsyncTypedDriver`, returning an async iterator:

```python
async for user in driver.paginate(driver.users.get_users, in_team=team_id):
    ...
```

## Safety

Misuse fails fast with a `TypeError` before any request: non-paginated methods,
positional arguments, raw `page=` (replaced by `start_page=`), and malformed
`items_from=` values. `null` item lists (Go nil slices) are treated as empty
pages, and non-JSON responses raise a descriptive error.

## Notes

- New docs page (`docs/pagination.rst`) covers all modes, including endpoints
  that require their own pagination flag (e.g. `paginate=True` on
  `get_groups_associated_to_channels_by_team`, which otherwise never terminates).
- Sync and async share one implementation via pager objects; covered by unit
  tests plus MockTransport integration tests through both drivers.
- Stacked on the retries PR (branched from `retries` for the test scaffolding);
  will retarget to `main` once that merges.